### PR TITLE
Sophos requires subnets to be in the same AZ

### DIFF
--- a/cf_templates/vpc.yml
+++ b/cf_templates/vpc.yml
@@ -59,7 +59,7 @@ Resources:
         -
           Key: "Name"
           Value: "Public"
-  PrivateSubnetAz3:
+  PrivateSubnetAz0:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
@@ -68,7 +68,7 @@ Resources:
         - - !Ref VpcSubnetPrefix
           - !FindInMap [SubnetConfig, Private, CIDR]
       AvailabilityZone: !Select
-        - 3
+        - 0
         - Fn::GetAZs: ""
       Tags:
         -
@@ -204,7 +204,7 @@ Resources:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
       SubnetId:
-        Ref: "PrivateSubnetAz3"
+        Ref: "PrivateSubnetAz0"
       RouteTableId:
         Ref: "PrivateRouteTable"
 Outputs:
@@ -223,7 +223,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet']]
   PrivateSubnet:
     Description: "SubnetId of the private subnet"
-    Value: !Ref PrivateSubnetAz3
+    Value: !Ref PrivateSubnetAz0
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet']]


### PR DESCRIPTION
Sophos setup video[1] says public and private subnet must be in the
same availability zone otherwise we will not be able to connect two
subnets to the same instance (the sophos utm instance).

[1] https://www.youtube.com/watch?v=7vjgVUUJyIc @ 5:40