### PR TITLE
Validate templates larger than 51K

### DIFF
--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 
-FILES=cf_templates/*
-for f in $FILES
+# Need to upload TEMPLATES to S3 before validating due to template-body MAX 51K length
+# https://docs.aws.amazon.com/cli/latest/reference/cloudformation/validate-template.html#options
+S3_BUCKET="bootstrap-awss3cloudformationbucket-19qromfd235z9"
+S3_BUCKET_URL="s3://$S3_BUCKET/$TRAVIS_BRANCH"
+TEMP_DIR="temp"
+
+# get list of templates
+pushd cf_templates
+TEMPLATES=*
+
+for f in $TEMPLATES
 do
-  echo -e "\nValidating CF template $f"
-  aws cloudformation validate-template --template-body file://$f
+  echo -e "\nUploading cf_templates to $S3_BUCKET_URL/$TEMP_DIR/$f"
+  aws s3 cp $f $S3_BUCKET_URL/$TEMP_DIR/$f
 done
 
-S3_TARGET_DIR="s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/$TRAVIS_BRANCH/"
-echo -e "\nUploading cf_templates to $S3_TARGET_DIR"
-aws s3 cp --recursive cf_templates $S3_TARGET_DIR
+TEMPLATE_URL="https://s3.amazonaws.com/$S3_BUCKET/$TRAVIS_BRANCH"
+for f in $TEMPLATES
+do
+  echo -e "\nValidating CF template $TEMPLATE_URL/$TEMP_DIR/$f"
+  aws cloudformation validate-template --template-url $TEMPLATE_URL/$TEMP_DIR/$f
+  aws s3 mv $S3_BUCKET_URL/$TEMP_DIR/$f $S3_BUCKET_URL/$f
+done
+
+popd
+


### PR DESCRIPTION
Files larger than 51K can only be validated if it's in an
S3 bucket[1] so we need to upload to S3 then validate with an
S3 url reference.

[1] https://docs.aws.amazon.com/cli/latest/reference/cloudformation/validate-template.html#options