### PR TITLE
Automate VPC Peering request

### DIFF
--- a/cf_templates/essentials.yml
+++ b/cf_templates/essentials.yml
@@ -6,6 +6,12 @@ Parameters:
   FhcrcVpnCidrip:
     Type: String
     NoEcho: true
+  VpcPeeringRequesterAwsAccountId:
+    Type: String
+    NoEcho: true
+    Description: The AWS account running the Sophos-VPN
+    AllowedPattern: '[0-9]*'
+    ConstraintDescription: Must be account number without dashes
 Resources:
   # resources for cloudtrail
   AWSLogsCloudtrailLogGroup:
@@ -308,6 +314,31 @@ Resources:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
       MaximumExecutionFrequency: TwentyFour_Hours
+  # Create a role to authorize the VPC Peering request from a specific account,
+  # this is used to create the VPC Peer between different accounts in  CloudFormation
+  # https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/VPCPeering
+  VPCPeeringAuthorizerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref VpcPeeringRequesterAwsAccountId
+                  - ':root'
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: VPCAuthorizer
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ec2:AcceptVpcPeeringConnection'
+                Resource:
+                  - '*'
 Outputs:
   AWSS3CloudtrailBucket:
     Value: !Ref AWSS3CloudtrailBucket
@@ -329,3 +360,8 @@ Outputs:
     Value: !Ref AWSSNSCloudformationNotifyLambdaTopic
     Export:
       Name: !Sub '${AWS::StackName}-CloudformationNotifyLambdaTopicArn'
+  VPCPeeringAuthorizerRole:
+    Description: Cross Account Role Name
+    Value: !Ref VPCPeeringAuthorizerRole
+    Export:
+      Name: !Sub '${AWS::StackName}-VPCPeeringAuthorizerRole'


### PR DESCRIPTION
When you request a VPC peering connection from one AWS account
(requester_account) to a VPC in another AWS account (a peer_account),
the VPC peering connection request must first be approved and accepted
by the peer_account to be activated. By default, the requester_account
cannot both request and also approve VPC peering connection requests
made to a different AWS peer_account.  AWS knowledge base article[1]
explain how to automate the approval of a peering request.  This CF
template code is from the awslabs repo[2]. Make it an essential resource
to every Sage VPC.

[1] https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-peering-vpc-different-account/
[2] https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/VPCPeering