### PR TITLE
Fix VPN security group

### DIFF
--- a/cf_templates/vpc.yml
+++ b/cf_templates/vpc.yml
@@ -397,7 +397,7 @@ Resources:
           Description: "Allow all VPN traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
-        - CidrIp: !GetAtt "VPC.CidrBlock"
+        - CidrIp: "0.0.0.0/0"
           FromPort: -1
           ToPort: -1
           IpProtocol: -1


### PR DESCRIPTION
Setting the outbound rule to VPC.Cidr block doesn't allow resources
in the private subnet to access the internet.  It should be set to
"0.0.0.0/0".