### PR TITLE
Bucket to store lambda artifacts

### DIFF
--- a/cf_templates/essentials.yml
+++ b/cf_templates/essentials.yml
@@ -250,6 +250,8 @@ Resources:
       S3BucketName: !Ref 'AWSS3ConfigBucket'
   AWSS3ConfigBucket:
     Type: AWS::S3::Bucket
+  AWSS3LambdaArtifactsBucket:
+    Type: AWS::S3::Bucket
   AWSSnsConfigTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -344,6 +346,10 @@ Outputs:
     Value: !Ref AWSS3CloudtrailBucket
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudtrailBucket'
+  AWSS3LambdaArtifactsBucket:
+    Value: !Ref AWSS3LambdaArtifactsBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LambdaArtifactsBucket'
   FhcrcVpnCidrip:
     Value: !Ref FhcrcVpnCidrip
     Export:


### PR DESCRIPTION
The process to run lambda code (python) with dependencies is to package
the code (including it's dependencies) into a zip file.  Upload the
zip file to an S3 bucket then reference the zip file from a
cloudformation script[1].  This change just creates the bucket to store
the lambda artifacts.

[1] https://github.com/awslabs/serverless-application-model/blob/master/HOWTO.md