### PR TITLE
Setup a role for CF deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,37 @@ Bootstrapping the account is a one time manual process:
 2. Goto Services -> Cloudformation
 3. Run the bootstrap.yaml template
 
-This will create the admin account (i.e. travis) required to deploy other
+This will create the account (i.e. travis) required to deploy other
 CF templates.
+
+## Deploying templates
+
+The travis account by itself does not have permissions to deploy templates.
+You must use Travis and assume the cloudformation service role.
+
+1. Setup ~/.aws/credentials file
+```
+[default]
+region = us-east-1
+[bridge.dev.travis]
+aws_access_key_id = <Access Key>
+aws_secret_access_key = <Secret Access Key>
+```
+
+2. Setup ~/.aws/config file
+```
+[default]
+region = us-east-1
+[profile bridge.dev.cfservice]
+role_arn = <CF Service Role Arn>
+source_profile = bridge.dev.travis
+```
+__NOTE__- source_profile needs to match the profile in ~/.aws/credentials file
+
+4. Assume CF service role to deploy templates
+```
+aws --profile bridge.dev.cfservice --region us-east-1 cloudformation create-stack ...
+```
 
 ## Create essential resources
 
@@ -20,7 +49,7 @@ pre-requesite for running this template is setup log aggregation from
 the the new account into logcentral.
 
 ```
-aws --profile bridge.dev.travis --region us-east-1 \
+aws --profile bridge.dev.cfservice --region us-east-1 \
 cloudformation create-stack --stack-name essentials \
 --capabilities CAPABILITY_NAMED_IAM \
 --template-url https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/essentials.yaml \
@@ -37,7 +66,7 @@ the resources has been setup you can access and view the account using the
 ## Create VPC
 
 ```
-aws --profile bridge.dev.travis --region us-east-1 \
+aws --profile bridge.dev.cfservice --region us-east-1 \
 cloudformation create-stack --stack-name vpc-bridge-develop \
 --capabilities CAPABILITY_NAMED_IAM \
 --template-url https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/vpc.yaml \
@@ -62,7 +91,7 @@ The sequence:
 3. Configure the VPC public and private route table with [vpc.yaml](./vpc.yaml) template
 
 ```
-aws --profile bridge.dev.travis --region us-east-1 \
+aws --profile bridge.dev.cfservice --region us-east-1 \
 cloudformation create-stack --stack-name peer-vpn-bridge-develop \
 --capabilities CAPABILITY_NAMED_IAM \
 --template-url https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/peer-route-config.yaml \

--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -42,6 +42,42 @@ Resources:
               AWS: "*"
             Action: "s3:GetObject"
             Resource: !Sub "arn:aws:s3:::${AWSS3CloudformationBucket}/*"
+  # CF Service roles
+  AWSIAMCfServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt AWSIAMTravisUser.Arn
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+  AWSIAMCfServicePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CfService"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action: "*"
+            Resource: "*"
+      Roles:
+        -
+          !Ref AWSIAMCfServiceRole
+  AWSIAMCfServiceInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+        -
+          !Ref AWSIAMCfServiceRole
 Outputs:
   AWSIAMTravisUser:
     Value: !Ref AWSIAMTravisUser
@@ -59,3 +95,7 @@ Outputs:
     Value: !Ref AWSS3CloudformationBucket
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudformationBucket'
+  AWSIAMCfServiceRoleArn:
+    Value: !GetAtt AWSIAMCfServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfServiceRoleArn'


### PR DESCRIPTION
It is an AWS security best practice[1] to execute tasks requiring elevated
permissions thru roles.  Refactor the travis user to deploy CF templates
thru a role.  This is more secure because roles execute tasks using
temporary one time access keys.

TODO: Modify the CI group permission to ReadOnlyAccess to force CI
users to use the CF service role to deploy templates.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html
