### PR TITLE
Make travis deploy with CF service role

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -21,7 +21,7 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
   # Cloudformation bucket for CF templates
   AWSS3CloudformationBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
Change CI group policy (which includes travis user) from admin to
read only.  The purpose is to make travis deploy CF templates
using the CF service role.

!Important: this will break CF deployment on *-infra repos that
have not been prepped[1] to use the CF service role.

[1] https://github.com/Sage-Bionetworks/aws-infra/pull/40