### PR TITLE
Revert "Make travis deploy with CF service role"

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -21,7 +21,7 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - arn:aws:iam::aws:policy/AdministratorAccess
   # Cloudformation bucket for CF templates
   AWSS3CloudformationBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
This reverts commit bdbd75dc5547ceba8306d9ace286a64f5d5908bd.
Non cloudformation projects (BridgePF, BridgeResearchUI, etc..)
use the travis s3 provider[1] to deploy artifacts. Changing
the travis user to read only breaks deployment on those projects.

[1] https://docs.travis-ci.com/user/deployment/s3/