### PR TITLE
update kms infra key access

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -253,8 +253,9 @@ Resources:
                   - ''
                   - - 'arn:aws:iam::'
                     - !Ref AWS::AccountId
-                    - ':user/'
-                    - !ImportValue us-east-1-bootstrap-TravisUser
+                    - ':root'
+                - !ImportValue us-east-1-bootstrap-TravisUserArn
+                - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
             Action:
               - "kms:Create*"
               - "kms:Describe*"
@@ -274,12 +275,8 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref AWS::AccountId
-                    - ':user/'
-                    - !ImportValue us-east-1-bootstrap-TravisUser
+                - !ImportValue us-east-1-bootstrap-TravisUserArn
+                - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"


### PR DESCRIPTION
All infra projects are now using the CF service role instead of the
travis to deploy.  Now we change access to the KMS key to the CF
service role as well.

This change requires a two step deployment process:
deploy 1: keep `us-east-1-bootstrap-TravisUser`
deploy 2: remove `us-east-1-bootstrap-TravisUser`