### PR TITLE
remove CF service instance profile

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -71,13 +71,6 @@ Resources:
       Roles:
         -
           !Ref AWSIAMCfServiceRole
-  AWSIAMCfServiceInstanceProfile:
-    Type: "AWS::IAM::InstanceProfile"
-    Properties:
-      Path: "/"
-      Roles:
-        -
-          !Ref AWSIAMCfServiceRole
 Outputs:
   # Deprecated, do not reference this!, use AWSIAMTravisUser instead
   AWSIAMTravisUserShortName:


### PR DESCRIPTION
An instance profile is not needed and it is not used by any dependent
resources.