### PR TITLE
[IT-427] Fix rotate credentials lambda

### DIFF
--- a/lambdas/RotateCredentials/ExpireAccessKeyLambda.py
+++ b/lambdas/RotateCredentials/ExpireAccessKeyLambda.py
@@ -55,6 +55,7 @@ def lambda_handler(event, context):
         SENDER_EMAIL = os.environ['SENDER_EMAIL']
         REPORT_TOPIC_ARN = os.environ['REPORT_TOPIC_ARN']
         GRACE_PERIOD = int(os.environ['GRACE_PERIOD'])
+        MAX_ACCESS_KEY_AGE = int(os.environ['MAX_ACCESS_KEY_AGE'])
     except (KeyError, ValueError, Exception) as e:
         logger.error(e.response['Error']['Message'])
 
@@ -65,7 +66,7 @@ def lambda_handler(event, context):
     report_message_deactivated_key = '\n\tAccess key {} for user {} has been deactivated.'
     report_message_expired_key = '\n\tAccess key {} for user {} has expired.'
 
-    max_age = get_max_password_age()  # password expiration setting
+    max_age = MAX_ACCESS_KEY_AGE  # access key expiration setting
     credential_report = get_credential_report()
 
     aws_account_identity = get_aws_account_identity()  # either account name or id
@@ -235,16 +236,6 @@ def email_user(sender, recipient, subject, body):
         else:
             logger.info("Email sent to " + RECIPIENT)
             logger.info("Message ID: " + response['MessageId'])
-
-
-# Get the AWS account's setting for password age
-def get_max_password_age():
-    iam_client = boto3.client('iam')
-    try:
-        response = iam_client.get_account_password_policy()
-        return response['PasswordPolicy']['MaxPasswordAge']
-    except ClientError as e:
-        logger.error(e.response['Error']['Message'])
 
 
 # Get the AWS account's credential report (in CSV) and return a list of credentials info

--- a/templates/RotateCredentials.yaml
+++ b/templates/RotateCredentials.yaml
@@ -35,6 +35,12 @@ Parameters:
     Description: A SES verified sender email address
     Type: String
     Default: "My AWS Account <user@example.com>"
+  MaxAccessKeyAge:
+    Description: The access key expiration period (in days)
+    Type: Number
+    Default: 180
+    MinValue: 7
+    MaxValue: 1800
 
 Resources:
   ExpireAccessKeyLambda:
@@ -52,6 +58,7 @@ Resources:
           SENDER_EMAIL: !Ref SenderEmail
           SEND_REPORT: !Ref SendReport
           REPORT_TOPIC_ARN: !ImportValue us-east-1-AccountAlertTopics-SNSAlertsInfoArn
+          MAX_ACCESS_KEY_AGE: !Ref MaxAccessKeyAge
       Code:
         S3Bucket: !Ref LambdaBucket
         S3Key: "aws-infra/master/RotateCredentials.zip"
@@ -148,7 +155,6 @@ Resources:
         - Name: FunctionName
           Value: !Ref ExpireAccessKeyLambda
       EvaluationPeriods: 1
-      MetricName: Errors
       Namespace: AWS/Lambda
       Period: 60
       Statistic: Sum


### PR DESCRIPTION
The lambda broke because 'enable password expiration' was disabled
in synapsedev and synapseprod accounts.  The lambda uses the
PasswordPolicy.MaxPasswordAge as the expiration age.  Since it was
disabled the API response did not contain that key.  We now de-couple
the password expiration age from the access key expiration age.
The expiration period for password and access key are now independent
and the key expiration age is passed in from the template that
deploys the rotate credentials lambda.