### PR TITLE
[IT-446] validate templates on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,22 @@ python: 3.5
 cache: pip
 fast_finish: true
 install:
-- wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
-- unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
-- ./setup_aws_cli.sh || travis_terminate 1
-script:
-# deploy artifacts to org-sagebase-admincentral
-- aws cloudformation package --template-file ./lambdas/rotate-credentials/template.yaml --output-template-file templates/rotate-credentials.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw
-- ./deploy_lambdas.sh || travis_terminate 1
-- ./validate-templates.sh || travis_terminate 1
-- ./deploy-templates.sh || travis_terminate 1
-
+  - pip install cfn-lint
+  - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
+  - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
+  - ./setup_aws_cli.sh || travis_terminate 1
+stages:
+  - name: validate
+  - name: deploy
+    if: branch = master AND type = push
+jobs:
+  include:
+    - stage: validate
+      script: 
+        - cfn-lint ./templates/**/*.yaml
+        - cfn-lint ./lambdas/**/*.yaml
+    - stage: deploy
+      script:
+        - aws cloudformation package --template-file ./lambdas/rotate-credentials/template.yaml --output-template-file templates/rotate-credentials.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw
+        - ./deploy_lambdas.sh || travis_terminate 1
+        - ./deploy-templates.sh || travis_terminate 1

--- a/templates/AccountAlertTopics.yaml
+++ b/templates/AccountAlertTopics.yaml
@@ -108,8 +108,8 @@ Resources:
       - Name: Currency
         Value: USD
       Statistic: Maximum
-      Period: '21600'
-      EvaluationPeriods: '1'
+      Period: 21600
+      EvaluationPeriods: 1
       Threshold: !Ref 'BillingThreshold'
       ComparisonOperator: GreaterThanThreshold
       AlarmActions: [!Ref 'SNSAlertsError']
@@ -149,7 +149,7 @@ Resources:
       Description: Send SNS Messages to Slack
       Runtime: python2.7
       Handler: index.lambda_handler
-      Timeout: '80'
+      Timeout: 80
       Code:
         ZipFile: |
           # Lambda to send SNS Messages to Slack

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -72,7 +72,7 @@ Resources:
       Topics:
         - !Ref AWSSNSCloudtrailTopic
       PolicyDocument:
-        Version: "2008-10-17"
+        Version: "2012-10-17"
         Statement:
           -
             Sid: "CloudtrailTopicPolicy"
@@ -117,10 +117,8 @@ Resources:
         - !Ref AWSIAMCloudtrailLogManagedPolicy
   AWSCloudtrailTrail:
     DependsOn:
-      - AWSLogsCloudtrailLogGroup
       - AWSIAMS3CloudtrailBucketPolicy
       - AWSSNSCloudtrailTopicPolicy
-      - AWSIAMCloudtrailLogRole
     Type: "AWS::CloudTrail::Trail"
     Properties:
       CloudWatchLogsLogGroupArn: !GetAtt AWSLogsCloudtrailLogGroup.Arn

--- a/templates/jumpcloud.yaml
+++ b/templates/jumpcloud.yaml
@@ -12,14 +12,12 @@ Parameters:
     NoEcho: true
 Resources:
   JumpcloudCleanSystems:
-    DependsOn:
-      - LambdaExecutionRole
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: clean_systems.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: python2.7
-      Timeout: '10'
+      Timeout: 10
       Environment:
         Variables:
           JC_SERVICE_API_KEY: !Ref JcServiceApiKey
@@ -75,7 +73,6 @@ Resources:
         - Name: FunctionName
           Value: !Ref JumpcloudCleanSystems
       EvaluationPeriods: 1
-      MetricName: Errors
       Namespace: AWS/Lambda
       Period: 60
       Statistic: Sum

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -22,6 +22,8 @@ Parameters:
     Description: CIDR of the (sophos-utm) VPN
     Type: String
     Default: "10.1.0.0/16"
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
 Mappings:
   SubnetConfig:
     VPC:
@@ -42,8 +44,8 @@ Resources:
   VPC:
     Type: "AWS::EC2::VPC"
     Properties:
-      EnableDnsSupport: "true"
-      EnableDnsHostnames: "true"
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
       CidrBlock: !Join
         - '.'
         - - !Ref VpcSubnetPrefix
@@ -282,27 +284,27 @@ Resources:
     Properties:
       NetworkAclId:
         Ref: "PublicNetworkAcl"
-      RuleNumber: "100"
-      Protocol: "-1"
+      RuleNumber: 100
+      Protocol: -1
       RuleAction: "allow"
-      Egress: "false"
+      Egress: false
       CidrBlock: "0.0.0.0/0"
       PortRange:
-        From: "0"
-        To: "65535"
+        From: 0
+        To: 65535
   OutboundPublicNetworkAclEntry:
     Type: "AWS::EC2::NetworkAclEntry"
     Properties:
       NetworkAclId:
         Ref: "PublicNetworkAcl"
-      RuleNumber: "100"
-      Protocol: "-1"
+      RuleNumber: 100
+      Protocol: -1
       RuleAction: "allow"
-      Egress: "true"
+      Egress: true
       CidrBlock: "0.0.0.0/0"
       PortRange:
-        From: "0"
-        To: "65535"
+        From: 0
+        To: 65535
   PublicSubnetNetworkAclAssociation:
     Type: "AWS::EC2::SubnetNetworkAclAssociation"
     Properties:
@@ -384,7 +386,6 @@ Resources:
         Ref: "PrivateRouteTable"
   # Allow access to EC2 when connected to the Sage VPN
   VpnSecurityGroup:
-    DependsOn: "VPC"
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: Security Group for VPN
@@ -394,14 +395,14 @@ Resources:
         - CidrIp: !Ref VpnCidr
           FromPort: -1
           ToPort: -1
-          IpProtocol: -1
+          IpProtocol: "-1"
           Description: "Allow all VPN traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"
           FromPort: -1
           ToPort: -1
-          IpProtocol: -1
+          IpProtocol: "-1"
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -419,7 +420,7 @@ Resources:
         - CidrIp: "0.0.0.0/0"
           FromPort: -1
           ToPort: -1
-          IpProtocol: -1
+          IpProtocol: "-1"
 Outputs:
   VPCId:
     Description: "VPCId of the newly created VPC"


### PR DESCRIPTION
Fix up the following lint errors:

E3012 Property Resources/SpendingAlarm/Properties/Period should be of type Integer
./templates/AccountAlertTopics.yaml:111:7

E3012 Property Resources/SpendingAlarm/Properties/EvaluationPeriods should be of type Integer
./templates/AccountAlertTopics.yaml:112:7

E3012 Property Resources/SlackNotificationLambda/Properties/Timeout should be of type Integer
./templates/AccountAlertTopics.yaml:152:7

W2511 IAM Policy Version should be updated to '2012-10-17'.
./templates/essentials.yaml:75:9

W3005 Obsolete DependsOn on resource (AWSLogsCloudtrailLogGroup), dependency already enforced by a "Fn:GetAtt" at Resources/AWSCloudtrailTrail/Properties/CloudWatchLogsLogGroupArn/Fn::GetAtt/['AWSLogsCloudtrailLogGroup', 'Arn']
./templates/essentials.yaml:119:5

W3005 Obsolete DependsOn on resource (AWSIAMCloudtrailLogRole), dependency already enforced by a "Fn:GetAtt" at Resources/AWSCloudtrailTrail/Properties/CloudWatchLogsRoleArn/Fn::GetAtt/['AWSIAMCloudtrailLogRole', 'Arn']
./templates/essentials.yaml:119:5

E0000 Duplicate resource found "MetricName" (line 78)
./templates/jumpcloud.yaml:78:7

W2509 AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/VpnCidr. Example for AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$"
./templates/vpc.yaml:21:3

E3012 Property Resources/VPC/Properties/EnableDnsSupport should be of type Boolean
./templates/vpc.yaml:45:7

E3012 Property Resources/VPC/Properties/EnableDnsHostnames should be of type Boolean
./templates/vpc.yaml:46:7

E3012 Property Resources/InboundHTTPPublicNetworkAclEntry/Properties/RuleNumber should be of type Integer
./templates/vpc.yaml:285:7

E3012 Property Resources/InboundHTTPPublicNetworkAclEntry/Properties/Protocol should be of type Integer
./templates/vpc.yaml:286:7

E3012 Property Resources/InboundHTTPPublicNetworkAclEntry/Properties/Egress should be of type Boolean
./templates/vpc.yaml:288:7

E3012 Property Resources/InboundHTTPPublicNetworkAclEntry/Properties/PortRange/From should be of type Integer
./templates/vpc.yaml:291:9

E3012 Property Resources/InboundHTTPPublicNetworkAclEntry/Properties/PortRange/To should be of type Integer
./templates/vpc.yaml:292:9

E3012 Property Resources/OutboundPublicNetworkAclEntry/Properties/RuleNumber should be of type Integer
./templates/vpc.yaml:298:7

E3012 Property Resources/OutboundPublicNetworkAclEntry/Properties/Protocol should be of type Integer
./templates/vpc.yaml:299:7

E3012 Property Resources/OutboundPublicNetworkAclEntry/Properties/Egress should be of type Boolean
./templates/vpc.yaml:301:7

E3012 Property Resources/OutboundPublicNetworkAclEntry/Properties/PortRange/From should be of type Integer
./templates/vpc.yaml:304:9

E3012 Property Resources/OutboundPublicNetworkAclEntry/Properties/PortRange/To should be of type Integer
./templates/vpc.yaml:305:9

W3005 Obsolete DependsOn on resource (VPC), dependency already enforced by a "Ref" at Resources/VpnSecurityGroup/Properties/VpcId/Ref/VPC
./templates/vpc.yaml:387:5

E3012 Property Resources/VpnSecurityGroup/Properties/SecurityGroupIngress/0/IpProtocol should be of type String
./templates/vpc.yaml:397:11

E3012 Property Resources/VpnSecurityGroup/Properties/SecurityGroupEgress/0/IpProtocol should be of type String
./templates/vpc.yaml:404:11

E3012 Property Resources/BastianSecurityGroup/Properties/SecurityGroupEgress/0/IpProtocol should be of type String
./templates/vpc.yaml:422:11