### PR TITLE
Setup cloudformation tests with taskcat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,8 @@ git-crypt.key
 # AWS lambdas
 lambdas/*.zip
 
+# taskcat
+/taskcat_outputs
+
+# temp files
+/temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 sudo: false
 language: python
-python: 3.5
+python: 3.6
 cache: pip
 fast_finish: true
 install:
   - pip install cfn-lint
+  - pip install taskcat
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
 stages:
   - name: validate
+  - name: test
+    if: branch = master AND type = push
   - name: deploy
     if: branch = master AND type = push
 jobs:
   include:
     - stage: validate
       script: 
-        - cfn-lint ./templates/**/*.yaml
-        - cfn-lint ./lambdas/**/*.yaml
+        - cfn-lint ./templates/**/*.yaml --ignore-checks W1001
+        - cfn-lint ./lambdas/**/*.yaml --ignore-checks W1001
+    - stage: test
+      script: taskcat -c ci/taskcat.yaml -P admincentral.cfservice --tag owner=travis
     - stage: deploy
       script:
         - aws cloudformation package --template-file ./lambdas/rotate-credentials/template.yaml --output-template-file templates/rotate-credentials.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw

--- a/README.md
+++ b/README.md
@@ -105,9 +105,16 @@ The above should configure the public and private routes for the VPC with
 the peering connection to the VPN.  That allows the VPN to direct traffic
 to this VPC.
 
+## Validation
+We have setup the CI to syntax validate cloudformation templates with cfn-lint.
+
+## Tests
+We have setup the CI to test cloudformation templates with
+[taskcat](https://github.com/aws-quickstart/taskcat).  Tests get run in the
+AWS Admincentral account.
 
 ## Continuous Integration
-We have configured Travis to deploy CF template to an S3 bucket on
+We have configured the CI to deploy CF template to an S3 bucket on the
 AWS Admincentral account.
 
 # Contributions

--- a/ci/AccountAlertTopics-input.json
+++ b/ci/AccountAlertTopics-input.json
@@ -1,0 +1,34 @@
+[
+    {
+        "ParameterKey": "InitialSubscriberEmail",
+        "ParameterValue": "taskcattest@sagebase.org"
+    },
+    {
+        "ParameterKey": "EnableSubscriberSMS",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "InitialSubscriberSMS",
+        "ParameterValue": "1-404-867-5309"
+    },
+    {
+        "ParameterKey": "BillingThreshold",
+        "ParameterValue": "$[taskcat_random-numbers]"
+    },
+    {
+        "ParameterKey": "DeployLambda",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "SlackWebhookURL",
+        "ParameterValue": "https://hooks.slack.com/services/slack-webhook-id"
+    },
+    {
+        "ParameterKey": "SlackChannel",
+        "ParameterValue": "#taskcattest"
+    },
+    {
+        "ParameterKey": "SlackIconEmoji",
+        "ParameterValue": ":cloud:"
+    }
+]

--- a/ci/AddSameRegionBucketDownloadRestriction-input.json
+++ b/ci/AddSameRegionBucketDownloadRestriction-input.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey": "BucketName",
+        "ParameterValue": "taskcat-tastcatsynapsebucket-oeg42xg2hitp"
+    }
+]

--- a/ci/ParkMyCloud-input.json
+++ b/ci/ParkMyCloud-input.json
@@ -1,0 +1,14 @@
+[
+    {
+        "ParameterKey": "PMCRoleName",
+        "ParameterValue": "$[taskcat_random-string]"
+    },
+    {
+        "ParameterKey": "PMCAccountID",
+        "ParameterValue": "753542375798"
+    },
+    {
+        "ParameterKey": "PMCExternalID",
+        "ParameterValue": "$[taskcat_random-numbers]"
+    }
+]

--- a/ci/bootstrap-input.json
+++ b/ci/bootstrap-input.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey": "CfBucketVersioning",
+        "ParameterValue": "Suspended"
+    }
+]

--- a/ci/jumpcloud-input.json
+++ b/ci/jumpcloud-input.json
@@ -1,0 +1,10 @@
+[
+    {
+        "ParameterKey": "JcServiceApiKey",
+        "ParameterValue": "$[taskcat_random-numbers]"
+    },
+    {
+        "ParameterKey": "LambdaBucket",
+        "ParameterValue": "essentials-awss3lambdaartifactsbucket-x29ftznj6pqw"
+    }
+]

--- a/ci/sumologic-role-input.json
+++ b/ci/sumologic-role-input.json
@@ -1,0 +1,14 @@
+[
+    {
+        "ParameterKey": "ExternalID",
+        "ParameterValue": "$[taskcat_random-numbers]"
+    },
+    {
+        "ParameterKey": "Actions",
+        "ParameterValue": "s3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket"
+    },
+    {
+        "ParameterKey": "Resource",
+        "ParameterValue": "arn:aws:s3:::testbucket-3npcu2i3v38u6ijg"
+    }
+]

--- a/ci/taskcat.yaml
+++ b/ci/taskcat.yaml
@@ -1,0 +1,53 @@
+---
+global:
+  package-lambda: true
+  owner: zaro0508@sagebase.org
+  qsname: aws-infra
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-west-1
+    - us-west-2
+tests:
+  sumologic-role:
+    parameter_input: sumologic-role-input.json
+    regions:
+      - us-east-1
+    template_file: sumologic-role.yaml
+  ParkMyCloud:
+    parameter_input: ParkMyCloud-input.json
+    regions:
+      - us-east-1
+    template_file: ParkMyCloud.yaml
+  AccountAlertTopics:
+    parameter_input: AccountAlertTopics-input.json
+    regions:
+      - us-east-1
+    template_file: AccountAlertTopics.yaml
+  jumpcloud:
+    parameter_input: jumpcloud-input.json
+    regions:
+      - us-east-1
+    template_file: jumpcloud.yaml
+  # test depends on resources in Sage-Bionetworks/admincentral-infra/config/prod/taskcat.yaml
+  AddSameRegionBucketDownloadRestriction:
+    parameter_input: AddSameRegionBucketDownloadRestriction-input.json
+    regions:
+      - us-east-1
+    template_file: AddSameRegionBucketDownloadRestriction.yaml
+  bootstrap:
+    parameter_input: bootstrap-input.json
+    regions:
+      - us-east-1
+    template_file: bootstrap.yaml
+  vpc:
+    parameter_input: vpc-input.json
+    regions:
+      - us-east-1
+    template_file: vpc.yaml

--- a/ci/vpc-input.json
+++ b/ci/vpc-input.json
@@ -1,0 +1,22 @@
+[
+    {
+        "ParameterKey": "VpcName",
+        "ParameterValue": "taskcattestvpc"
+    },
+    {
+        "ParameterKey": "VpcSubnetPrefix",
+        "ParameterValue": "10.254"
+    },
+    {
+        "ParameterKey": "PublicSubnetZones",
+        "ParameterValue": "$[taskcat_genaz_3]"
+    },
+    {
+        "ParameterKey": "PrivateSubnetZones",
+        "ParameterValue": "$[taskcat_genaz_3]"
+    },
+    {
+        "ParameterKey": "VpnCidr",
+        "ParameterValue": "10.1.0.0/16"
+    }
+]


### PR DESCRIPTION
Use taskcat[1] to test cloudformation templates.  Taskcat tests
templates by deploying resources to an AWS account then tearing
them all down afterwards.  This makes sure that templates can actually
provision resources to the AWS account in a specified AZ.  We
only test on "us-east-1" because that's the only AZ we use.

Taskcat is a bit opinionated about it's directory structure so
we could not include the rotate-credentials lambda.  We also
have a few issues with CF templates that make them difficult to test:

https://sagebionetworks.jira.com/browse/IT-475
https://sagebionetworks.jira.com/browse/IT-476

[1] https://github.com/aws-quickstart/taskcat