### PR TITLE
[IT-497] make SynapseUserName an optional parameter

### DIFF
--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -36,6 +36,7 @@ Parameters:
   SynapseUserName:
     Type: String
     Description: Synapse user for read-write bucket
+    Default: ""
   Department:
     Description: The department for this resource (i.e. Computational Oncology)
     Type: String
@@ -79,6 +80,7 @@ Conditions:
   EnableEncryption: !Equals [!Ref EncryptBucket, true]
   DisableEncryption: !Not [!Condition EnableEncryption]
   CreateIPAddressRestrictionLambda: !Equals [!Ref SameRegionResourceAccessToBucket, true]
+  HasSynapseUserName: !Not [!Equals [!Ref SynapseUserName, ""]]
 Resources:
   SynapseExternalBucket:
     Type: "AWS::S3::Bucket"
@@ -200,6 +202,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseExternalBucket'
   SynapseUserName:
+    Condition: HasSynapseUserName
     Value: !Ref SynapseUserName
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseUserName'


### PR DESCRIPTION
Users may only want to provision a generic bucket.  The SynapseUserName
parameter is not applicable in those cases.  Do not not deploy a
owner.txt file in those cases.

This requires refactoring the sceptre "synapse_bucket_notify" hook[1] to
not create an owner.txt file when `synapse_username` is not specified.

[1] https://github.com/Sage-Bionetworks/sceptre-provisioner-hooks/pull/4