### PR TITLE
[IT-480] Add templates for AWS Batch

### DIFF
--- a/ci/managed-batch-input.json
+++ b/ci/managed-batch-input.json
@@ -1,0 +1,22 @@
+[
+    {
+        "ParameterKey": "VpcName",
+        "ParameterValue": "it-services"
+    },
+    {
+        "ParameterKey": "Department",
+        "ParameterValue": "Platform"
+    },
+    {
+        "ParameterKey": "Project",
+        "ParameterValue": "Infrastructure"
+    },
+    {
+        "ParameterKey": "OwnerEmail",
+        "ParameterValue": "taskcat@sagebase.org"
+    },
+    {
+        "ParameterKey": "ContainerCommands",
+        "ParameterValue": "['echo', 'Hello World']"
+    }
+]

--- a/ci/taskcat.yaml
+++ b/ci/taskcat.yaml
@@ -1,7 +1,7 @@
 ---
 global:
   package-lambda: true
-  owner: zaro0508@sagebase.org
+  owner: tcisagebio@sagebase.org
   qsname: aws-infra
   regions:
     - ap-northeast-1
@@ -61,6 +61,11 @@ tests:
     regions:
       - us-east-1
     template_file: ec2-backup.yaml
+  managed-batch:
+    parameter_input: managed-batch-input.json
+    regions:
+      - us-east-1
+    template_file: managed-batch.yaml
   # Stack deletion fails when taskcat attempts to delete bucket
   # s3web-bucket:
   #   parameter_input: s3web-bucket-input.json

--- a/templates/managed-batch.yaml
+++ b/templates/managed-batch.yaml
@@ -187,11 +187,6 @@ Resources:
       ServiceRole: !Ref 'BatchServiceRole'
   PeriodicSchedulerLambda:
     Condition: EnablePeriodicSchedule
-    DependsOn:
-      - HighPriorityJobDefinition
-      - LowPriorityJobDefinition
-      - HighPriorityJobQueue
-      - LowPriorityJobQueue
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       # template uploaded from Sage-Bionetworks/aws-infra repo
@@ -200,18 +195,8 @@ Resources:
         Department: !Ref Department
         Project: !Ref Project
         OwnerEmail: !Ref OwnerEmail
-        JobName: !Join
-          - '-'
-          - - !Ref AWS::StackName
-            - "high-priority-job"
-        JobQueue: !Join
-          - '-'
-          - - !Ref AWS::StackName
-            - "high-priority-queue"
-        JobDefinition: !Join
-          - '-'
-          - - !Ref AWS::StackName
-            - "high-priority-job:1"
+        JobDefinitionArn: !Ref 'HighPriorityJobDefinition'
+        JobQueueArn: !Ref 'HighPriorityJobQueue'
         ScheduleExpression: !Ref ScheduleExpression
       Tags:
         - Key: "Name"

--- a/templates/managed-batch.yaml
+++ b/templates/managed-batch.yaml
@@ -158,7 +158,7 @@ Resources:
           Department: !Ref Department
           Project: !Ref Project
           OwnerEmail: !Ref OwnerEmail
-      ServiceRole: !Ref 'BatchServiceRole'
+      ServiceRole: !GetAtt BatchServiceRole.Arn
   SpotComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
@@ -178,13 +178,13 @@ Resources:
           - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet2
         InstanceRole: !Ref 'IamInstanceProfile'
         BidPercentage: 40
-        SpotIamFleetRole: !Ref 'SpotIamFleetRole'
+        SpotIamFleetRole: !GetAtt SpotIamFleetRole.Arn
         Tags:
           Name: !Ref 'AWS::StackName'
           Department: !Ref Department
           Project: !Ref Project
           OwnerEmail: !Ref OwnerEmail
-      ServiceRole: !Ref 'BatchServiceRole'
+      ServiceRole: !GetAtt BatchServiceRole.Arn
   PeriodicSchedulerLambda:
     Condition: EnablePeriodicSchedule
     Type: 'AWS::CloudFormation::Stack'

--- a/templates/managed-batch.yaml
+++ b/templates/managed-batch.yaml
@@ -1,0 +1,249 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Managed High Priority and Low Priority Batch Job Queue using simple EC2
+  and Spot Compute Environments.
+Parameters:
+  VpcName:
+    Description: Name of an existing VPC to run the instance in.
+    Type: String
+  Department:
+    Description: The department for this resource (i.e. Computational Oncology)
+    Type: String
+  Project:
+    Description: The name of the project that this resource is used for (i.e. Resilience)
+    Type: String
+  OwnerEmail:
+    Description: The owner's email address for this resource (i.e. jsmith@sagebase.org)
+    Type: String
+  ContainerImage:
+    Description: The container image (i.e. 137112412989.dkr.ecr.us-east-1.amazonaws.com/amazonlinux:latest)
+    Type: String
+    Default: "137112412989.dkr.ecr.us-east-1.amazonaws.com/amazonlinux:latest"
+  ContainerCommands:
+    Type: CommaDelimitedList
+    Description: Container command to execute
+    ConstraintDescription: "List of commands (i.e. ['echo', 'Hello World'])"
+  PeriodicSchedule:
+    Type: String
+    Description: "Execute batch job on a periodic schehdule"
+    Default: "Enabled"
+    AllowedValues:
+      - "Enabled"
+      - "Disabled"
+    ConstraintDescription: "Valid values are Enabled (default) and Disabled"
+  ScheduleExpression:  #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+    Description: The schedule (cron) expression to trigger the batch job
+    Type: String
+    Default: "rate(1 day)"
+Conditions:
+  EnablePeriodicSchedule: !Equals [!Ref PeriodicSchedule, "Enabled"]
+Resources:
+  BatchServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: batch.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
+  IamInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref 'EcsInstanceRole'
+  EcsInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2008-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+  SpotIamFleetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: spotfleet.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole
+  HighPriorityJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - "high-priority-job"
+      ContainerProperties:
+        Image: !Ref ContainerImage
+        Vcpus: 2
+        Memory: 2000
+        Command: !Ref ContainerCommands
+      RetryStrategy:
+        Attempts: 1
+  LowPriorityJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - "low-priority-job"
+      ContainerProperties:
+        Image: !Ref ContainerImage
+        Vcpus: 2
+        Memory: 2000
+        Command: !Ref ContainerCommands
+      RetryStrategy:
+        Attempts: 1
+  HighPriorityJobQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - "high-priority-queue"
+      Priority: 1
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref 'OnDemandComputeEnvironment'
+        - Order: 2
+          ComputeEnvironment: !Ref 'SpotComputeEnvironment'
+  LowPriorityJobQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - "low-priority-queue"
+      Priority: 2
+      ComputeEnvironmentOrder:
+        - Order: 1
+          ComputeEnvironment: !Ref 'SpotComputeEnvironment'
+  OnDemandComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      ComputeResources:
+        Type: EC2
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: 64
+        InstanceTypes:
+          - optimal
+        SecurityGroupIds:
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-VpnSecurityGroup
+        Subnets:
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet1
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet2
+        InstanceRole: !Ref 'IamInstanceProfile'
+        Tags:
+          Name: !Ref 'AWS::StackName'
+          Department: !Ref Department
+          Project: !Ref Project
+          OwnerEmail: !Ref OwnerEmail
+      ServiceRole: !Ref 'BatchServiceRole'
+  SpotComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      ComputeResources:
+        Type: SPOT
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: 64
+        InstanceTypes:
+          - optimal
+        SecurityGroupIds:
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-VpnSecurityGroup
+        Subnets:
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet1
+          - 'Fn::ImportValue': !Sub us-east-1-${VpcName}-PrivateSubnet2
+        InstanceRole: !Ref 'IamInstanceProfile'
+        BidPercentage: 40
+        SpotIamFleetRole: !Ref 'SpotIamFleetRole'
+        Tags:
+          Name: !Ref 'AWS::StackName'
+          Department: !Ref Department
+          Project: !Ref Project
+          OwnerEmail: !Ref OwnerEmail
+      ServiceRole: !Ref 'BatchServiceRole'
+  PeriodicSchedulerLambda:
+    Condition: EnablePeriodicSchedule
+    DependsOn:
+      - HighPriorityJobDefinition
+      - LowPriorityJobDefinition
+      - HighPriorityJobQueue
+      - LowPriorityJobQueue
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      # template uploaded from Sage-Bionetworks/aws-infra repo
+      TemplateURL: 'https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/periodic-batch-scheduler.yaml'
+      Parameters:
+        Department: !Ref Department
+        Project: !Ref Project
+        OwnerEmail: !Ref OwnerEmail
+        JobName: !Join
+          - '-'
+          - - !Ref AWS::StackName
+            - "high-priority-job"
+        JobQueue: !Join
+          - '-'
+          - - !Ref AWS::StackName
+            - "high-priority-queue"
+        JobDefinition: !Join
+          - '-'
+          - - !Ref AWS::StackName
+            - "high-priority-job:1"
+        ScheduleExpression: !Ref ScheduleExpression
+      Tags:
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+Outputs:
+  HighPriorityJobDefinitionArn:
+    Value: !Ref 'HighPriorityJobDefinition'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-HighPriorityJobDefinitionArn'
+  LowPriorityJobDefinitionArn:
+    Value: !Ref 'LowPriorityJobDefinition'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LowPriorityJobDefinitionArn'
+  HighPriorityJobQueueArn:
+    Value: !Ref 'HighPriorityJobQueue'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-HighPriorityJobQueueArn'
+  LowPriorityJobQueueArn:
+    Value: !Ref 'LowPriorityJobQueue'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LowPriorityJobQueueArn'
+  OnDemandComputeEnvironmentArn:
+    Value: !Ref 'OnDemandComputeEnvironment'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OnDemandComputeEnvironmentArn'
+  SpotComputeEnvironmentArn:
+    Value: !Ref 'SpotComputeEnvironment'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SpotComputeEnvironmentArn'

--- a/templates/periodic-batch-scheduler.yaml
+++ b/templates/periodic-batch-scheduler.yaml
@@ -1,0 +1,179 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Lambda to schedule periodic execution of a batch job
+Parameters:
+  Department:
+    Description: The department for this resource (i.e. Computational Oncology)
+    Type: String
+  Project:
+    Description: The name of the project that this resource is used for (i.e. Resilience)
+    Type: String
+  OwnerEmail:
+    Description: The owner's email address for this resource (i.e. jsmith@sagebase.org)
+    Type: String
+  JobName:
+    Description: The batch job name (i.e. MyBatchJob)
+    Type: String
+  JobQueue:
+    Description: Run the batch job on this job queue
+    Type: String
+  JobDefinition:
+    Description: The job definition (i.e. MyBatchJob:1)
+    Type: String
+  ScheduleExpression:  #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+    Description: The schedule (cron) expression to trigger the batch job
+    Type: String
+    Default: "rate(1 day)"
+  LambdaFailureAlarmAction:
+    Description: The alarm failure action
+    Type: String
+    Default: "us-east-1-AccountAlertTopics-SNSAlertsErrorArn"
+Resources:
+  LambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: PublishToCloudwatch
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+        - PolicyName: BatchJobAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - batch:DescribeJobs
+                  - batch:ListJobs
+                  - batch:SubmitJob
+                Resource: "*"
+  SubmitBatchJobLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.6
+      Timeout: 5
+      Handler: index.lambda_handler
+      Environment:
+        Variables:
+          JOB_NAME: !Ref JobName
+          JOB_QUEUE: !Ref JobQueue
+          JOB_DEFINITION: !Ref JobDefinition
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import json
+          import logging
+          import os
+          import boto3
+          from botocore.exceptions import ClientError
+
+          logger = logging.getLogger(__name__)
+          logger.setLevel(logging.DEBUG)
+
+          def lambda_handler(event, context):
+              # Log the received event
+              logger.debug("Received event: " + json.dumps(event, indent=2))
+
+              # Get parameters for the SubmitJob call
+              # http://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html
+              # These should be passed in via Lambda Environment Variables
+              try:
+                  jobName = os.environ['JOB_NAME']
+                  jobQueue = os.environ['JOB_QUEUE']
+                  jobDefinition = os.environ['JOB_DEFINITION']
+              except (KeyError, ValueError, Exception) as e:
+                  logger.error(e.response['Error']['Message'])
+
+              # containerOverrides and parameters are optional
+              if event.get('containerOverrides'):
+                  containerOverrides = event['containerOverrides']
+              else:
+                  containerOverrides = {}
+              if event.get('parameters'):
+                  parameters = event['parameters']
+              else:
+                  parameters = {}
+
+              try:
+                  batch = boto3.client('batch')
+                  # Submit a Batch Job
+                  response = batch.submit_job(jobQueue=jobQueue, jobName=jobName, jobDefinition=jobDefinition,
+                                              containerOverrides=containerOverrides, parameters=parameters)
+                  # Return the jobId
+                  jobId = response['jobId']
+
+                  # Log response from AWS Batch
+                  logger.debug("Job: " + jobId + " Response: " + json.dumps(response, indent=2))
+                  return {
+                      'jobId': jobId
+                  }
+              except ClientError as e:
+                  logger.error(e.response['Error']['Message'])
+      Tags:
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  LambdaPeriodicEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: !Ref ScheduleExpression
+      Targets:
+        - Arn: !GetAtt SubmitBatchJobLambda.Arn
+          Id: !Ref SubmitBatchJobLambda
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SubmitBatchJobLambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt LambdaPeriodicEvent.Arn
+  LambdaFailureAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - 'Fn::ImportValue': !Sub '${LambdaFailureAlarmAction}'
+      MetricName: !Sub "${SubmitBatchJobLambda}-FailureAlarm"
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref SubmitBatchJobLambda
+      EvaluationPeriods: 1
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+Outputs:
+  LambdaFailureAlarm:
+    Value: !Ref 'LambdaFailureAlarm'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LambdaFailureAlarm'
+  SubmitBatchJobLambda:
+    Value: !Ref 'SubmitBatchJobLambda'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SubmitBatchJobLambda'
+  LambdaExecutionRole:
+    Value: !Ref 'LambdaExecutionRole'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LambdaExecutionRole'

--- a/templates/periodic-batch-scheduler.yaml
+++ b/templates/periodic-batch-scheduler.yaml
@@ -11,14 +11,11 @@ Parameters:
   OwnerEmail:
     Description: The owner's email address for this resource (i.e. jsmith@sagebase.org)
     Type: String
-  JobName:
-    Description: The batch job name (i.e. MyBatchJob)
+  JobDefinitionArn:
+    Description: Job definition ARN (i.e. arn:aws:batch:us-east-1:111111111111:job-definition/my-job:1)
     Type: String
-  JobQueue:
-    Description: Run the batch job on this job queue
-    Type: String
-  JobDefinition:
-    Description: The job definition (i.e. MyBatchJob:1)
+  JobQueueArn:
+    Description: Job queue ARN (i.e. arn:aws:batch:us-east-1:111111111111:job-queue/my-job-queue)
     Type: String
   ScheduleExpression:  #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
     Description: The schedule (cron) expression to trigger the batch job
@@ -71,9 +68,8 @@ Resources:
       Handler: index.lambda_handler
       Environment:
         Variables:
-          JOB_NAME: !Ref JobName
-          JOB_QUEUE: !Ref JobQueue
-          JOB_DEFINITION: !Ref JobDefinition
+          JOB_DEFINITION_ARN: !Ref JobDefinitionArn
+          JOB_QUEUE_ARN: !Ref JobQueueArn
       Code:
         ZipFile: |
           from __future__ import print_function
@@ -94,9 +90,12 @@ Resources:
               # http://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html
               # These should be passed in via Lambda Environment Variables
               try:
-                  jobName = os.environ['JOB_NAME']
-                  jobQueue = os.environ['JOB_QUEUE']
-                  jobDefinition = os.environ['JOB_DEFINITION']
+                  jobDefinitionArn = os.environ['JOB_DEFINITION_ARN']
+                  jobQueueArn = os.environ['JOB_QUEUE_ARN']
+                  jobName = jobDefinitionArn.split(":")[-2].split("/")[-1]
+                  jobRevision = jobDefinitionArn.split(":")[-1]
+                  jobDefinition = jobName + ":" + jobRevision
+                  jobQueue = jobQueueArn.split(":")[-1].split("/")[-1]
               except (KeyError, ValueError, Exception) as e:
                   logger.error(e.response['Error']['Message'])
 


### PR DESCRIPTION
Create CF templates to provision AWS Batch jobs.  This template will
create a batch job on two queues, a high priority and low pritority
queue. The high priority queue runs on regular instances while the low
priority queue will run jobs with spot instances.  It uses a nested
stack to provision a lambda to run the batch job on a periodic
schedule.