### PR TITLE
[IT-520] Add CF template to backup EC2

### DIFF
--- a/ci/ec2-backup-input.json
+++ b/ci/ec2-backup-input.json
@@ -1,0 +1,10 @@
+[
+    {
+        "ParameterKey": "StackName",
+        "ParameterValue": "$[taskcat_random-string]"
+    },
+    {
+        "ParameterKey": "SnapshotCount",
+        "ParameterValue": "1"
+    }
+]

--- a/ci/taskcat.yaml
+++ b/ci/taskcat.yaml
@@ -56,6 +56,11 @@ tests:
     regions:
       - us-east-1
     template_file: s3-bucket.yaml
+  ec2-backup:
+    parameter_input: ec2-backup-input.json
+    regions:
+      - us-east-1
+    template_file: ec2-backup.yaml
   # Stack deletion fails when taskcat attempts to delete bucket
   # s3web-bucket:
   #   parameter_input: s3web-bucket-input.json

--- a/templates/ec2-backup.yaml
+++ b/templates/ec2-backup.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Backup EC2 with the Data Lifecycle Manager
+Parameters:
+  StackName:
+    Description: The stack name, used as the backup target tag
+    Type: String
+  SnapshotCount:
+    Description: The number of snapshots to keep
+    Type: Number
+    MinValue: 1
+    MaxValue: 180
+    Default: 7
+    ConstraintDescription: Valid values is 1-180
+Resources:
+  Ec2DataLifecyclePolicy:
+    Type: "AWS::DLM::LifecyclePolicy"
+    Properties:
+      Description: "EC2 back up policy"
+      State: "ENABLED"
+      ExecutionRoleArn: !ImportValue
+        'Fn::Sub': ${AWS::Region}-essentials-AWSDataLifecycleManagerDefaultRoleArn
+      PolicyDetails:
+        ResourceTypes:
+          - "VOLUME"
+        # This policy will be applied to volumes with any of the following tags.
+        # You cannot use tags that are in use by another enabled or disabled lifecycle policy
+        TargetTags:
+          -
+            Key: "cloudformation:stack-name"
+            Value: !Ref StackName
+        Schedules:
+          -
+            Name: "Daily Snapshots"
+            TagsToAdd:
+              -
+                Key: "Type"
+                Value: "DailySnapshot"
+            CreateRule:
+              Interval: 24
+              IntervalUnit: "HOURS"
+              Times:
+                - "13:00"
+            RetainRule:
+              Count: !Ref SnapshotCount
+            CopyTags: true
+


### PR DESCRIPTION
Add a cloudformation template to enable backing up EC2 instances
using the data lifecycle manager[1].  This is template is meant to be
used as a nested template.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dlm-lifecyclepolicy.html