### PR TITLE
[IT-520] setup a role for DLM

### DIFF
--- a/templates/dlm-role.yaml
+++ b/templates/dlm-role.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Setup a role for the data life cycle manager
+Resources:
+  # Role for Data Lifecycle Manager (DLM)
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html
+  AWSDataLifecycleManagerDefaultRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "dlm.amazoneaws.com"
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: "DefaultDLM"
+          PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ec2:CreateSnapshot"
+                  - "ec2:DeleteSnapshot"
+                  - "ec2:DescribeVolumes"
+                  - "ec2:DescribeSnapshots"
+                Resource:
+                  - '*'
+              - Effect: "Allow"
+                Action:
+                  - "ec2:CreateTags"
+                Resource:
+                  - 'arn:aws:ec2:*::snapshot/*'
+Outputs:
+  AWSDataLifecycleManagerDefaultRoleArn:
+    Description: Default Data Lifecycle Manager role arn
+    Value: !GetAtt AWSDataLifecycleManagerDefaultRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSDataLifecycleManagerDefaultRoleArn'
+


### PR DESCRIPTION
Create a scheduled backup using the data lifecycle manager requires
a role.  We create a generic role for the DLM so we can provision
multiple DLM instances on each account.