### PR TITLE
[IT-529] Update synapse bucket permissions

### DIFF
--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -160,7 +160,9 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS: !Ref GrantAccess
-            Action: "s3:ListBucket*"
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
             Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
           -
             Sid: "WriteAccess"


### PR DESCRIPTION
As explained in these updated instructions:
https://github.com/Sage-Bionetworks/synapseDocs/pull/538/files

When an S3 bucket is to be used with Synapse it needs to grant Synapse
`S3:GetBucketLocation` permission, so Synapse can determine the Region
and configure the S3 client accordingly.