### PR TITLE
update defaults

### DIFF
--- a/templates/managed-ec2-v7.yaml
+++ b/templates/managed-ec2-v7.yaml
@@ -6,7 +6,7 @@ Parameters:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: 'AWS::EC2::KeyPair::KeyName'
     ConstraintDescription: must be the name of an existing EC2 KeyPair.
-    Default: "sandbox"
+    Default: ""
   InstanceType:
     Description: WebServer EC2 instance type
     Type: String
@@ -166,6 +166,7 @@ Parameters:
     ConstraintDescription: Valid values are 1-180
 Conditions:
   PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
+  HasKeyName: !Not [!Equals ["", !Ref KeyName]]
   HasAMIId: !Not [!Equals ["", !Ref AMIId]]
   EnableOpenPort: !Not [!Equals ["0", !Ref OpenPort]]
   AllowPortAccess: !And [!Condition PublicEc2Resources, !Condition EnableOpenPort]
@@ -332,76 +333,20 @@ Mappings:
       Arch: HVM64
   AWSRegionArch2AMI:
     us-east-1:
-      PV64: ami-2a69aa47
-      HVM64: ami-97785bed
-      HVMG2: ami-0a6e3770
+      PV64:  NOT_SUPPORTED
+      HVM64: ami-0080e4c5bc078760e
+      HVMG2: NOT_SUPPORTED
     us-west-2:
-      PV64: ami-7f77b31f
-      HVM64: ami-f2d3638a
-      HVMG2: ami-ee15a196
+      PV64: NOT_SUPPORTED
+      HVM64: ami-01e24be29428c15b2
+      HVMG2: NOT_SUPPORTED
     us-west-1:
-      PV64: ami-a2490dc2
-      HVM64: ami-824c4ee2
-      HVMG2: ami-0da4a46d
-    eu-west-1:
-      PV64: ami-4cdd453f
-      HVM64: ami-d834aba1
-      HVMG2: ami-af8013d6
-    eu-west-2:
       PV64: NOT_SUPPORTED
-      HVM64: ami-403e2524
+      HVM64: ami-0ec6517f6edbf8044
       HVMG2: NOT_SUPPORTED
-    eu-west-3:
-      PV64: NOT_SUPPORTED
-      HVM64: ami-8ee056f3
-      HVMG2: NOT_SUPPORTED
-    eu-central-1:
-      PV64: ami-6527cf0a
-      HVM64: ami-5652ce39
-      HVMG2: ami-1d58ca72
-    ap-northeast-1:
-      PV64: ami-3e42b65f
-      HVM64: ami-ceafcba8
-      HVMG2: ami-edfd658b
-    ap-northeast-2:
-      PV64: NOT_SUPPORTED
-      HVM64: ami-863090e8
-      HVMG2: NOT_SUPPORTED
-    ap-northeast-3:
-      PV64: NOT_SUPPORTED
-      HVM64: ami-83444afe
-      HVMG2: NOT_SUPPORTED
-    ap-southeast-1:
-      PV64: ami-df9e4cbc
-      HVM64: ami-68097514
-      HVMG2: ami-c06013bc
-    ap-southeast-2:
-      PV64: ami-63351d00
-      HVM64: ami-942dd1f6
-      HVMG2: ami-85ef12e7
-    ap-south-1:
-      PV64: NOT_SUPPORTED
-      HVM64: ami-531a4c3c
-      HVMG2: ami-411e492e
     us-east-2:
       PV64: NOT_SUPPORTED
-      HVM64: ami-f63b1193
-      HVMG2: NOT_SUPPORTED
-    ca-central-1:
-      PV64: NOT_SUPPORTED
-      HVM64: ami-a954d1cd
-      HVMG2: NOT_SUPPORTED
-    sa-east-1:
-      PV64: ami-1ad34676
-      HVM64: ami-84175ae8
-      HVMG2: NOT_SUPPORTED
-    cn-north-1:
-      PV64: ami-77559f1a
-      HVM64: ami-cb19c4a6
-      HVMG2: NOT_SUPPORTED
-    cn-northwest-1:
-      PV64: ami-80707be2
-      HVM64: ami-3e60745c
+      HVM64: ami-0cd3dfa4e37921605
       HVMG2: NOT_SUPPORTED
 Resources:
   InstanceSecurityGroup:
@@ -495,7 +440,7 @@ Resources:
     Properties:
       ImageId: !If [HasAMIId, !Ref AMIId, !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref InstanceType, Arch]]]
       InstanceType: !Ref InstanceType
-      KeyName: !Ref KeyName
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
       BlockDeviceMappings:
         -
           DeviceName: "/dev/xvda"


### PR DESCRIPTION
* remove regions that are not supported
* make keyname an optional parameter. if nothing specified no SSH key pair will
be assigned to the instance.