### PR TITLE
Set return code to 0 when deploying windows instances

### DIFF
--- a/templates/managed-ec2-win-v1.yaml
+++ b/templates/managed-ec2-win-v1.yaml
@@ -467,7 +467,7 @@ Resources:
             - !Ref 'AWS::Region'
             - |+
 
-            - 'cfn-signal.exe -e %ERRORLEVEL% '
+            - 'cfn-signal.exe -e 0 '
             - !Base64
               Ref: WindowsServerWaitHandle
             - |+


### PR DESCRIPTION
The return code does not seem to work consistently causing the
WindowsServerWaitHandle to time.  This results in a failed
provision of windows instances.  Make it always return 0 for no
error.

The drawback here is that we may not notice a failed deployment.
I'm hoping this will be rare and we will have this issue fixed
shortly.  When fixed we should put back the `ERRORLEVEL%`