### PR TITLE
increase ubuntu deployment timeout

### DIFF
--- a/templates/managed-ec2-ubuntu-v1.yaml
+++ b/templates/managed-ec2-ubuntu-v1.yaml
@@ -531,7 +531,7 @@ Resources:
           Value: !Ref OwnerEmail
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT5M
+        Timeout: PT10M
   Ec2Backup:
     Type: 'AWS::CloudFormation::Stack'
     Condition: EnableEc2Backup


### PR DESCRIPTION
Deploying large instances with large volumes requires more time.