### PR TITLE
update managed ebs mount location

### DIFF
--- a/templates/managed-ebs.yaml
+++ b/templates/managed-ebs.yaml
@@ -61,7 +61,7 @@ Parameters:
   AttachmentDevice:
     Description: How the device is exposed to the instance (e.g., /dev/sdh, or xvdh)
     Type: String
-    Default: "/dev/xvda"
+    Default: "/dev/xvdm"     # xvda is reserved for root volume
 Conditions:
   HasIops: !Not [!Equals ["99", !Ref Iops]]
   HasSnapshotId: !Not [!Equals ["", !Ref SnapshotId]]


### PR DESCRIPTION
The "/dev/xvda" attachment location is typically the root volume
valid locations are xvd[a to z].  We mount extra volume at "xvdam"

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html