### PR TITLE
fix linter errors in templates

### DIFF
--- a/templates/managed-ec2-ubuntu-v1.yaml
+++ b/templates/managed-ec2-ubuntu-v1.yaml
@@ -424,7 +424,7 @@ Resources:
               owner: root
               group: root
             /lib/systemd/system/cfn-hup.service:
-              content: !Sub |
+              content: |
                 [Unit]
                 Description=cfn-hup daemon
 

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -76,7 +76,7 @@ Parameters:
     Default: 365000
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
-  AllowUserAccess: !Not [!Equals [!Join ['', !Ref GrantAccess], "[]"]]
+  AllowUserAccess: !Not [!Equals [!Ref GrantAccess, "[]"]]
   EnableEncryption: !Equals [!Ref EncryptBucket, true]
   DisableEncryption: !Not [!Condition EnableEncryption]
   CreateIPAddressRestrictionLambda: !Equals [!Ref SameRegionResourceAccessToBucket, true]


### PR DESCRIPTION
This fixes the following linter errors:

W1020 Fn::Sub isn't needed because there are no variables at Resources/Ec2Instance/Metadata/AWS::CloudFormation::Init/configure_cfn/files//lib/systemd/system/cfn-hup.service/content/Fn::Sub
templates/managed-ec2-ubuntu-v1.yaml:427:15

E8003 Fn::Equals element must be a string, Ref, or a Fn::FindInMap
templates/s3-bucket.yaml:79:3