### PR TITLE
Revert "fix linter errors in templates (#125)"

### DIFF
--- a/templates/managed-ec2-ubuntu-v1.yaml
+++ b/templates/managed-ec2-ubuntu-v1.yaml
@@ -424,7 +424,7 @@ Resources:
               owner: root
               group: root
             /lib/systemd/system/cfn-hup.service:
-              content: |
+              content: !Sub |
                 [Unit]
                 Description=cfn-hup daemon
 

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -76,7 +76,7 @@ Parameters:
     Default: 365000
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
-  AllowUserAccess: !Not [!Equals [!Ref GrantAccess, "[]"]]
+  AllowUserAccess: !Not [!Equals [!Join ['', !Ref GrantAccess], "[]"]]
   EnableEncryption: !Equals [!Ref EncryptBucket, true]
   DisableEncryption: !Not [!Condition EnableEncryption]
   CreateIPAddressRestrictionLambda: !Equals [!Ref SameRegionResourceAccessToBucket, true]


### PR DESCRIPTION
This reverts commit 1d1145590b215b18a283ec96bca230f25bb6b13e.
Need to revert due to taskcat issue
https://github.com/aws-quickstart/taskcat/issues/280