### PR TITLE
pin cfn-lint to ver 0.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 3.6
 cache: pip
 fast_finish: true
 install:
-  - pip install cfn-lint
+  - pip install cfn-lint==0.19.0
   - pip install taskcat
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"


### PR DESCRIPTION
Need to pin to a cfn-lint version due to taskcat issue
https://github.com/aws-quickstart/taskcat/issues/280