### PR TITLE
update supported ec2 instances

### DIFF
--- a/templates/managed-ec2-ubuntu-v1.yaml
+++ b/templates/managed-ec2-ubuntu-v1.yaml
@@ -12,7 +12,11 @@ Parameters:
     Type: String
     Default: t2.nano
     AllowedValues:
-      - t1.micro
+      - a1.medium
+      - a1.large
+      - a1.xlarge
+      - a1.2xlarge
+      - a1.4xlarge
       - t2.nano
       - t2.micro
       - t2.small
@@ -185,8 +189,16 @@ Conditions:
   EnableEc2Backup: !Equals [!Ref BackupEc2, true]
 Mappings:
   AWSInstanceType2Arch:
-    t1.micro:
-      Arch: PV64
+    a1.medium:
+      Arch: HVM64
+    a1.large:
+      Arch: HVM64
+    a1.xlarge:
+      Arch: HVM64
+    a1.2xlarge:
+      Arch: HVM64
+    a1.4xlarge:
+      Arch: HVM64
     t2.nano:
       Arch: HVM64
     t2.micro:

--- a/templates/managed-ec2-v8.j2
+++ b/templates/managed-ec2-v8.j2
@@ -12,7 +12,11 @@ Parameters:
     Type: String
     Default: t2.nano
     AllowedValues:
-      - t1.micro
+      - a1.medium
+      - a1.large
+      - a1.xlarge
+      - a1.2xlarge
+      - a1.4xlarge
       - t2.nano
       - t2.micro
       - t2.small
@@ -176,8 +180,16 @@ Conditions:
   EnableEc2Backup: !Equals [!Ref BackupEc2, true]
 Mappings:
   AWSInstanceType2Arch:
-    t1.micro:
-      Arch: PV64
+    a1.medium:
+      Arch: HVM64
+    a1.large:
+      Arch: HVM64
+    a1.xlarge:
+      Arch: HVM64
+    a1.2xlarge:
+      Arch: HVM64
+    a1.4xlarge:
+      Arch: HVM64
     t2.nano:
       Arch: HVM64
     t2.micro:


### PR DESCRIPTION
Remove support for t1 instances they are deprecated.
Add support for a1 instances for aws linux and ubuntu linux.
a1 is not supported for windows.

https://aws.amazon.com/ec2/pricing/on-demand/