### PR TITLE
Refactor ec2 templates

### DIFF
--- a/templates/managed-ec2-v9.j2
+++ b/templates/managed-ec2-v9.j2
@@ -1,0 +1,560 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Default: ""
+  InstanceType:
+    Description: WebServer EC2 instance type
+    Type: String
+    Default: t3.nano
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - m1.small
+      - m1.medium
+      - m1.large
+      - m1.xlarge
+      - m2.xlarge
+      - m2.2xlarge
+      - m2.4xlarge
+      - m3.medium
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.12xlarge
+      - m5.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.12xlarge
+      - m5d.24xlarge
+      - c1.medium
+      - c1.xlarge
+      - c3.large
+      - c3.xlarge
+      - c3.2xlarge
+      - c3.4xlarge
+      - c3.8xlarge
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.18xlarge
+      - g2.2xlarge
+      - g2.8xlarge
+      - r3.large
+      - r3.xlarge
+      - r3.2xlarge
+      - r3.4xlarge
+      - r3.8xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - i2.xlarge
+      - i2.2xlarge
+      - i2.4xlarge
+      - i2.8xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - hs1.8xlarge
+      - cr1.8xlarge
+      - cc2.8xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+  JcConnectKey:
+    Description: Connection key used to let JC agent connect to a Jumpcloud account.
+    Type: String
+    NoEcho: true
+  JcServiceApiKey:
+    Description: The Jumpcloud service user API key
+    Type: String
+    NoEcho: true
+  JcSystemsGroupId:
+    Description: Put EC2 into this Jumpcloud systems group
+    Type: String
+    NoEcho: true
+  VpcSubnet:
+    Description: Name of an existing VPC subnet to run the instance in.
+    Type: String
+    Default: PrivateSubnet
+    ConstraintDescription: >-
+      Allowed values (PrivateSubnet, PrivateSubnet1, PrivateSubnet2, PublicSubnet, PublicSubnet1, PublicSubnet2)
+    AllowedValues:
+      - PrivateSubnet
+      - PrivateSubnet1
+      - PrivateSubnet2
+      - PublicSubnet
+      - PublicSubnet1
+      - PublicSubnet2
+  VpcName:
+    Description: 'Name of an existing VPC to run the instance in'
+    Type: String
+    Default: sandcastlevpc
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+  ParkMyCloudManaged:
+    Description: Allow ParkMyCloud service to start/stop resources
+    Type: String
+    Default: 'yes'
+  AMIId:
+    Description: ID of the AMI to deploy
+    Type: String
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 8
+    MinValue: 8
+    MaxValue: 1000
+  BackupEc2:
+    Type: String
+    Description: true to enable daily EC2 backup, false (default) for no backup
+    AllowedValues:
+      - true
+      - false
+    Default: false
+  SnapshotCount:
+    Description: The number of snapshots to keep, only used if BackupEc2=true
+    Type: Number
+    MinValue: 1
+    MaxValue: 180
+    Default: 7
+    ConstraintDescription: Valid values are 1-180
+Conditions:
+  PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
+  HasKeyName: !Not [!Equals ["", !Ref KeyName]]
+  HasAMIId: !Not [!Equals ["", !Ref AMIId]]
+  EnableEc2Backup: !Equals [!Ref BackupEc2, true]
+Mappings:
+  AWSInstanceType2Arch:
+    t2.nano:
+      Arch: HVM64
+    t2.micro:
+      Arch: HVM64
+    t2.small:
+      Arch: HVM64
+    t2.medium:
+      Arch: HVM64
+    t2.large:
+      Arch: HVM64
+    t2.xlarge:
+      Arch: HVM64
+    t2.2xlarge:
+      Arch: HVM64
+    t3.nano:
+      Arch: HVM64
+    t3.micro:
+      Arch: HVM64
+    t3.small:
+      Arch: HVM64
+    t3.medium:
+      Arch: HVM64
+    t3.large:
+      Arch: HVM64
+    t3.xlarge:
+      Arch: HVM64
+    t3.2xlarge:
+      Arch: HVM64
+    m1.small:
+      Arch: PV64
+    m1.medium:
+      Arch: PV64
+    m1.large:
+      Arch: PV64
+    m1.xlarge:
+      Arch: PV64
+    m2.xlarge:
+      Arch: PV64
+    m2.2xlarge:
+      Arch: PV64
+    m2.4xlarge:
+      Arch: PV64
+    m3.medium:
+      Arch: HVM64
+    m3.large:
+      Arch: HVM64
+    m3.xlarge:
+      Arch: HVM64
+    m3.2xlarge:
+      Arch: HVM64
+    m4.large:
+      Arch: HVM64
+    m4.xlarge:
+      Arch: HVM64
+    m4.2xlarge:
+      Arch: HVM64
+    m4.4xlarge:
+      Arch: HVM64
+    m4.10xlarge:
+      Arch: HVM64
+    m5.large:
+      Arch: HVM64
+    m5.xlarge:
+      Arch: HVM64
+    m5.2xlarge:
+      Arch: HVM64
+    m5.4xlarge:
+      Arch: HVM64
+    m5.12xlarge:
+      Arch: HVM64
+    m5.24xlarge:
+      Arch: HVM64
+    m5d.large:
+      Arch: HVM64
+    m5d.xlarge:
+      Arch: HVM64
+    m5d.2xlarge:
+      Arch: HVM64
+    m5d.4xlarge:
+      Arch: HVM64
+    m5d.12xlarge:
+      Arch: HVM64
+    m5d.24xlarge:
+      Arch: HVM64
+    c1.medium:
+      Arch: PV64
+    c1.xlarge:
+      Arch: PV64
+    c3.large:
+      Arch: HVM64
+    c3.xlarge:
+      Arch: HVM64
+    c3.2xlarge:
+      Arch: HVM64
+    c3.4xlarge:
+      Arch: HVM64
+    c3.8xlarge:
+      Arch: HVM64
+    c4.large:
+      Arch: HVM64
+    c4.xlarge:
+      Arch: HVM64
+    c4.2xlarge:
+      Arch: HVM64
+    c4.4xlarge:
+      Arch: HVM64
+    c4.8xlarge:
+      Arch: HVM64
+    c5.large:
+      Arch: HVM64
+    c5.xlarge:
+      Arch: HVM64
+    c5.2xlarge:
+      Arch: HVM64
+    c5.4xlarge:
+      Arch: HVM64
+    c5.9xlarge:
+      Arch: HVM64
+    c5.18xlarge:
+      Arch: HVM64
+    g2.2xlarge:
+      Arch: HVMG2
+    g2.8xlarge:
+      Arch: HVMG2
+    r3.large:
+      Arch: HVM64
+    r3.xlarge:
+      Arch: HVM64
+    r3.2xlarge:
+      Arch: HVM64
+    r3.4xlarge:
+      Arch: HVM64
+    r3.8xlarge:
+      Arch: HVM64
+    r4.large:
+      Arch: HVM64
+    r4.xlarge:
+      Arch: HVM64
+    r4.2xlarge:
+      Arch: HVM64
+    r4.4xlarge:
+      Arch: HVM64
+    r4.8xlarge:
+      Arch: HVM64
+    r4.16xlarge:
+      Arch: HVM64
+    i2.xlarge:
+      Arch: HVM64
+    i2.2xlarge:
+      Arch: HVM64
+    i2.4xlarge:
+      Arch: HVM64
+    i2.8xlarge:
+      Arch: HVM64
+    d2.xlarge:
+      Arch: HVM64
+    d2.2xlarge:
+      Arch: HVM64
+    d2.4xlarge:
+      Arch: HVM64
+    d2.8xlarge:
+      Arch: HVM64
+    hs1.8xlarge:
+      Arch: HVM64
+    cr1.8xlarge:
+      Arch: HVM64
+    cc2.8xlarge:
+      Arch: HVM64
+  AWSRegionArch2AMI:
+    us-east-1:
+      PV64:  NOT_SUPPORTED
+      HVM64: ami-0080e4c5bc078760e
+      HVMG2: NOT_SUPPORTED
+    us-west-2:
+      PV64: NOT_SUPPORTED
+      HVM64: ami-01e24be29428c15b2
+      HVMG2: NOT_SUPPORTED
+    us-west-1:
+      PV64: NOT_SUPPORTED
+      HVM64: ami-0ec6517f6edbf8044
+      HVMG2: NOT_SUPPORTED
+    us-east-2:
+      PV64: NOT_SUPPORTED
+      HVM64: ami-0cd3dfa4e37921605
+      HVMG2: NOT_SUPPORTED
+Resources:
+  {% if sceptre_user_data.OpenPorts is defined %}
+  InstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: "Open a port for incoming traffic"
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+      SecurityGroupIngress:
+      {% for port in sceptre_user_data.OpenPorts %}
+        - CidrIp: "0.0.0.0/0"
+          FromPort: {{ port }}
+          ToPort: {{ port }}
+          IpProtocol: tcp
+      {% endfor %}
+      SecurityGroupEgress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+  {% endif %}
+  Ec2Instance:
+    Type: 'AWS::EC2::Instance'
+    Metadata:
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - configure_cfn
+          SetupJumpcloud:
+            - Install_JC
+            - Config_JC
+          SetupVolume:
+            - TagRootVolume
+        configure_cfn:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+                verbose=true
+                interval=5
+              mode: "000400"
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupJumpcloud,SetupVolume --region ${AWS::Region}
+              mode: "000400"
+              owner: root
+              group: root
+            /lib/systemd/system/cfn-hup.service:
+              content: !Sub |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/opt/aws/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+              mode: "000400"
+              owner: root
+              group: root
+          commands:
+            01_enable_cfn-hup:
+              command: "/bin/systemctl enable cfn-hup.service"
+            02_start_cfn-hup:
+              command: "/bin/systemctl start cfn-hup.service"
+        Install_JC:
+          packages:
+            yum:
+              jq: []
+          commands:
+            01_jumpcloud_agent:
+              command: !Join
+                - ''
+                - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
+                  - !Ref JcConnectKey
+                  - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
+        Config_JC:
+          commands:
+            # allow agent time to register with jumpcloud account
+            01_wait_registeration:
+              command: "sleep 10"
+            02_associate_jc_systems:
+              command: !Join
+                - ''
+                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); /usr/bin/curl -X POST 'https://console.jumpcloud.com/api/v2/systemgroups/"
+                  - !Ref JcSystemsGroupId
+                  - "/members' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  - !Ref JcServiceApiKey
+                  - "' -d '{\"op\": \"add\",\"type\": \"system\",\"id\": \"'$JC_SYSTEM_ID'\"}'"
+        TagRootVolume:
+          commands:
+            01_tag_root_disk:
+              command: !Join
+                - ''
+                - - "EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id) "
+                  - "ROOT_DISK_ID=$(/usr/bin/aws ec2 describe-volumes --region $AWS_REGION "
+                  - "--filters Name=attachment.instance-id,Values=$EC2_INSTANCE_ID "
+                  - "--query Volumes[].VolumeId --out text); "
+                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
+                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
+                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                DEPARTMENT: !Ref Department
+                PROJECT: !Ref Project
+                OWNER_EMAIL: !Ref OwnerEmail
+    Properties:
+      ImageId: !If [HasAMIId, !Ref AMIId, !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref InstanceType, Arch]]]
+      InstanceType: !Ref InstanceType
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      BlockDeviceMappings:
+        -
+          DeviceName: "/dev/xvda"
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+      NetworkInterfaces:
+        - DeleteOnTermination: true
+          DeviceIndex: "0"
+          GroupSet:
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+            - !If [PublicEc2Resources, 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-BastianSecurityGroup', !Ref 'AWS::NoValue']
+          {% if sceptre_user_data.OpenPorts is defined %}
+            - !GetAtt InstanceSecurityGroup.GroupId
+          {% endif %}
+          SubnetId: !ImportValue
+            'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
+      IamInstanceProfile: !ImportValue
+        'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumeProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          /bin/yum update -y aws-cfn-bootstrap
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupJumpcloud,SetupVolume --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource Ec2Instance --region ${AWS::Region}
+      Tags:
+        - Key: "parkmycloud"
+          Value: !Ref ParkMyCloudManaged
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT5M
+  Ec2Backup:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: EnableEc2Backup
+    Properties:
+      # template uploaded from Sage-Bionetworks/aws-infra repo
+      TemplateURL: 'https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/ec2-backup.yaml'
+      Parameters:
+        StackName: !Ref AWS::StackName
+        SnapshotCount: !Ref SnapshotCount
+      Tags:
+        - Key: "parkmycloud"
+          Value: !Ref ParkMyCloudManaged
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+Outputs:
+  Ec2InstanceId:
+    Value: !Ref Ec2Instance
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstanceId'
+  Ec2InstancePrivateIp:
+    Value: !GetAtt Ec2Instance.PrivateIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePrivateIp'
+  Ec2InstancePublicIp:
+    Condition: PublicEc2Resources
+    Value: !GetAtt Ec2Instance.PublicIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePublicIp'
+  OwnerEmail:
+    Value: !Ref OwnerEmail
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'

--- a/templates/managed-ec2-v9.j2
+++ b/templates/managed-ec2-v9.j2
@@ -387,13 +387,13 @@ Resources:
       'AWS::CloudFormation::Init':
         configSets:
           SetupCfn:
-            - configure_cfn
+            - cfn_hup_service
           SetupJumpcloud:
-            - Install_JC
-            - Config_JC
+            - install_jc
+            - config_jc
           SetupVolume:
-            - TagRootVolume
-        configure_cfn:
+            - tag_volume
+        cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
               content: !Sub |
@@ -434,7 +434,7 @@ Resources:
               command: "/bin/systemctl enable cfn-hup.service"
             02_start_cfn-hup:
               command: "/bin/systemctl start cfn-hup.service"
-        Install_JC:
+        install_jc:
           packages:
             yum:
               jq: []
@@ -445,7 +445,7 @@ Resources:
                 - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
                   - !Ref JcConnectKey
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
-        Config_JC:
+        config_jc:
           commands:
             # allow agent time to register with jumpcloud account
             01_wait_registeration:
@@ -458,7 +458,7 @@ Resources:
                   - "/members' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
                   - !Ref JcServiceApiKey
                   - "' -d '{\"op\": \"add\",\"type\": \"system\",\"id\": \"'$JC_SYSTEM_ID'\"}'"
-        TagRootVolume:
+        tag_volume:
           commands:
             01_tag_root_disk:
               command: !Join

--- a/templates/managed-ec2-win-v3.j2
+++ b/templates/managed-ec2-win-v3.j2
@@ -347,77 +347,73 @@ Resources:
     Metadata:
       'AWS::CloudFormation::Init':
         configSets:
-          GeneralSetup:
-            - auto_reloader
+          SetupCfn:
+            - cfn_hup_service
+          SetupApps:
             - install_apps
-          JumpcloudSetup:
+          SetupJumpcloud:
             - install_jc
-        auto_reloader:
+            - config_jc
+          SetupVolume:
+            - tag_volume
+        # Cfn-hup setting, it is to monitor the change of metadata.
+        # When there is change in the contents of json file in the metadata section, cfn-hup will call cfn-init.
+        cfn_hup_service:
           files:
-            'c:\cfn\cfn-hup.conf':
-              content: !Join
-                - ''
-                - - |
-                    [main]
-                  - stack=
-                  - !Ref 'AWS::StackId'
-                  - |+
-
-                  - region=
-                  - !Ref 'AWS::Region'
-                  - |+
-            'c:\cfn\hooks.d\cfn-auto-reloader.conf':
-              content: !Join
-                - ''
-                - - |
-                    [cfn-auto-reloader-hook]
-                  - |
-                    triggers=post.update
-                  - |
-                    path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
-                  - 'action=cfn-init.exe -v -s '
-                  - !Ref 'AWS::StackId'
-                  - ' -r Ec2Instance'
-                  - ' --region '
-                  - !Ref 'AWS::Region'
-                  - |+
+             "c:\\cfn\\cfn-hup.conf":
+               content: !Sub |
+                 [main]
+                 stack=${AWS::StackId}
+                 region=${AWS::Region}
+                 interval=1
+             "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf":
+               content: !Sub |
+                 [cfn-auto-reloader-hook]
+                 triggers=post.update
+                 path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
+                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud,SetupVolume
           services:
             windows:
               cfn-hup:
-                enabled: true
-                ensureRunning: true
+                enabled: 'true'
+                ensureRunning: 'true'
                 files:
-                  - 'c:\cfn\cfn-hup.conf'
-                  - 'c:\cfn\hooks.d\cfn-auto-reloader.conf'
+                  - "c:\\cfn\\cfn-hup.conf"
+                  - "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf"
         install_apps:
           files:
-            'c:\scripts\install-chocolatey.ps1':
+            'c:\\scripts\\install-chocolatey.ps1':
               source: "https://chocolatey.org/install.ps1"
+              mode: "0664"
           commands:
-            1-install-chocolatey:
+            01_install_nuget:
+              command: 'Powershell.exe Install-PackageProvider -Name NuGet -Force'
+            02_install_chocolatey:
               command: !Join
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
                   - 'Powershell.exe C:\scripts\install-chocolatey.ps1 > C:\scripts\install-chocolatey.log'
-            2-install-jq:
+            03_install_jq:
               command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install jq --yes'
-            3-install-googlechrome:
+            04_install_awscli:
+              command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install awscli --yes'
+            05_install_googlechrome:
               command: 'Powershell.exe C:\ProgramData\chocolatey\bin\choco install googlechrome  --yes'
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
               source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-ms-vc.ps1"
-            'c:\scripts\install-jc-agent.ps1':
+              mode: "0664"
+            'c:\\scripts\\install-jc-agent.ps1':
               source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-jc-agent.ps1"
-            'c:\scripts\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/associate-jc-system.ps1"
+              mode: "0664"
           commands:
-            1-install-ms-vc:
+            01_install_ms_vc:
               command: !Join
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
                   - 'Powershell.exe C:\scripts\install-ms-vc.ps1 > C:\scripts\install-ms-vc.log'
-            2-install-jc-agent:
+            02_install_jc_agent:
               command: !Join
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
@@ -425,7 +421,13 @@ Resources:
                   - ' -JcConnectKey '
                   - !Ref JcConnectKey
                   - ' > C:\scripts\install-jc-agent.log'
-            3-associate-jc-system:
+        config_jc:
+          files:
+            'c:\\scripts\\associate-jc-system.ps1':
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/associate-jc-system.ps1"
+              mode: "0664"
+          commands:
+            01_associate_jc_systems:
               command: !Join
                 - ''
                 - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
@@ -435,6 +437,28 @@ Resources:
                   - ' -JcSystemsGroupId '
                   - !Ref JcSystemsGroupId
                   - ' > C:\scripts\associate-jc-system.log'
+        tag_volume:
+          files:
+             "c:\\scripts\\tag-instance-volume.ps1":
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/tag-instance-volume.ps1"
+              mode: "0664"
+          commands:
+            01_tag_instance_volume:
+              command: !Join
+                - ''
+                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
+                  - 'Powershell.exe C:\scripts\tag-instance-volume.ps1 '
+                  - ' -AwsRegion '
+                  - !Ref AWS::Region
+                  - ' -StackName '
+                  - !Ref AWS::StackName
+                  - ' -Department '
+                  - !Ref Department
+                  - ' -Project '
+                  - !Ref Project
+                  - ' -OwnerEmail '
+                  - !Ref OwnerEmail
+                  - ' > C:\scripts\tag-instance-volume.log'
     Properties:
       ImageId: !If [HasAMIId, !Ref AMIId, !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref InstanceType, Arch]]]
       InstanceType: !Ref InstanceType
@@ -459,26 +483,12 @@ Resources:
             'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
       IamInstanceProfile: !ImportValue
         'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumeProfile'
-      UserData: !Base64
-        'Fn::Join':
-          - ''
-          - - |
-              <script>
-            - 'cfn-init.exe -v -s '
-            - !Ref 'AWS::StackName'
-            - ' -r Ec2Instance '
-            - ' --configsets GeneralSetup,JumpcloudSetup '
-            - ' --region '
-            - !Ref 'AWS::Region'
-            - |+
-
-            - 'cfn-signal.exe -e 0 '
-            - !Base64
-              Ref: WindowsServerWaitHandle
-            - |+
-
-            - |
-              </script>
+      UserData:
+        Fn::Base64: !Sub |
+          <script>
+          cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud,SetupVolume
+          cfn-signal.exe -e %errorlevel% --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region}
+          </script>
       Tags:
         - Key: "parkmycloud"
           Value: !Ref ParkMyCloudManaged
@@ -490,14 +500,10 @@ Resources:
           Value: !Ref Project
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail
-  WindowsServerWaitHandle:
-    Type: 'AWS::CloudFormation::WaitConditionHandle'
-  WindowsServerWaitCondition:
-    Type: 'AWS::CloudFormation::WaitCondition'
-    DependsOn: Ec2Instance
-    Properties:
-      Handle: !Ref WindowsServerWaitHandle
-      Timeout: '1000'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: "PT30M"
   Ec2Backup:
     Type: 'AWS::CloudFormation::Stack'
     Condition: EnableEc2Backup


### PR DESCRIPTION
Refactor managed-ec2 (aws linux) template:
* update default instance type from t2.nan to t3.nano
* update naming convention from camel case to undercores
* add cloudformation auto reloader service
* simplify jumpcloud setup and configuration

Refactor managed-ec2 (aws windows) template:
* simplify auto reloader using aws labs example[1]
* add awscli install to instance
* split install_jc to two steps, install and config
* add step to tag the EC2 root volume
* simplify UserData section
* replace WindowsServerWaitHandle with CreationPolicy. AWS recommends using the latter
* update naming convention from camel case to undercores

[1] https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/solutions/AmazonCloudWatchAgent/inline/windows.template)
