### PR TITLE
[IT-553] Restrictive access to EC2 instances

### DIFF
--- a/templates/managed-ec2-ubuntu-v2.j2
+++ b/templates/managed-ec2-ubuntu-v2.j2
@@ -454,11 +454,17 @@ Resources:
             02_associate_jc_systems:
               command: !Join
                 - ''
-                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); /usr/bin/curl -X POST 'https://console.jumpcloud.com/api/v2/systemgroups/"
-                  - !Ref JcSystemsGroupId
-                  - "/members' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
+                  - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
                   - !Ref JcServiceApiKey
-                  - "' -d '{\"op\": \"add\",\"type\": \"system\",\"id\": \"'$JC_SYSTEM_ID'\"}'"
+                  - "' | jq -r '.results | .[] | select(.email==\""
+                  - !Ref OwnerEmail
+                  - "\") | .id'); "
+                  - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  - !Ref JcServiceApiKey
+                  - "' -d '{\"attributes\":{\"sudo\":{\"enabled\":true,\"withoutPassword\":false}},\"op\":\"add\",\"type\":\"system\",\"id\":\"'$JC_SYSTEM_ID'\"}'"
         TagRootVolume:
           commands:
             01_tag_root_disk:

--- a/templates/managed-ec2-v9.j2
+++ b/templates/managed-ec2-v9.j2
@@ -453,11 +453,17 @@ Resources:
             02_associate_jc_systems:
               command: !Join
                 - ''
-                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); /usr/bin/curl -X POST 'https://console.jumpcloud.com/api/v2/systemgroups/"
-                  - !Ref JcSystemsGroupId
-                  - "/members' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
+                  - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
                   - !Ref JcServiceApiKey
-                  - "' -d '{\"op\": \"add\",\"type\": \"system\",\"id\": \"'$JC_SYSTEM_ID'\"}'"
+                  - "' | jq -r '.results | .[] | select(.email==\""
+                  - !Ref OwnerEmail
+                  - "\") | .id'); "
+                  - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  - !Ref JcServiceApiKey
+                  - "' -d '{\"attributes\":{\"sudo\":{\"enabled\":true,\"withoutPassword\":false}},\"op\":\"add\",\"type\":\"system\",\"id\":\"'$JC_SYSTEM_ID'\"}'"
         tag_volume:
           commands:
             01_tag_root_disk:

--- a/templates/managed-ec2-win-v1.yaml
+++ b/templates/managed-ec2-win-v1.yaml
@@ -393,9 +393,9 @@ Resources:
             'c:\scripts\install-chocolatey.ps1':
               source: "https://chocolatey.org/install.ps1"
             'c:\scripts\install-ms-vc.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-ms-vc.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/install-ms-vc.ps1"
             'c:\scripts\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/install-jc-agent.ps1"
           commands:
             1-install-chocolatey:
               command: !Join
@@ -420,7 +420,7 @@ Resources:
         setup_jc:
           files:
             'c:\scripts\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/associate-jc-system.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/associate-jc-system.ps1"
           commands:
             1-associate-jc-system:
               command: !Join

--- a/templates/managed-ec2-win-v2.yaml
+++ b/templates/managed-ec2-win-v2.yaml
@@ -411,11 +411,11 @@ Resources:
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-ms-vc.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/install-ms-vc.ps1"
             'c:\scripts\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/install-jc-agent.ps1"
             'c:\scripts\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/associate-jc-system.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.0/aws/associate-jc-system.ps1"
           commands:
             1-install-ms-vc:
               command: !Join

--- a/templates/managed-ec2-win-v3.j2
+++ b/templates/managed-ec2-win-v3.j2
@@ -402,10 +402,10 @@ Resources:
         install_jc:
           files:
             'c:\scripts\install-ms-vc.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-ms-vc.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.1/aws/install-ms-vc.ps1"
               mode: "0664"
             'c:\\scripts\\install-jc-agent.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/install-jc-agent.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.1/aws/install-jc-agent.ps1"
               mode: "0664"
           commands:
             01_install_ms_vc:
@@ -424,7 +424,7 @@ Resources:
         config_jc:
           files:
             'c:\\scripts\\associate-jc-system.ps1':
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/associate-jc-system.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.1/aws/associate-jc-system.ps1"
               mode: "0664"
           commands:
             01_associate_jc_systems:
@@ -436,11 +436,13 @@ Resources:
                   - !Ref JcServiceApiKey
                   - ' -JcSystemsGroupId '
                   - !Ref JcSystemsGroupId
+                  - ' -OwnerEmail '
+                  - !Ref OwnerEmail
                   - ' > C:\scripts\associate-jc-system.log'
         tag_volume:
           files:
              "c:\\scripts\\tag-instance-volume.ps1":
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/master/aws/tag-instance-volume.ps1"
+              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.1/aws/tag-instance-volume.ps1"
               mode: "0664"
           commands:
             01_tag_instance_volume:


### PR DESCRIPTION
Instead of giving a group access to a provisioned EC2 we change to
only give the EC2 owner access to the provisioned instance.  Jumpcloud
configurations for AWS linux and ubuntu requests are handled in the
CFN template. Jumpcloud config for windows is handled in a powershell
script updated in PR https://github.com/Sage-Bionetworks/infra-utils/pull/33