### PR TITLE
support addition s3 storage class

### DIFF
--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -66,6 +66,8 @@ Parameters:
     Type: String
     Description: S3 bucket objects will transition into this storage class
     AllowedValues:
+      - DEEP_ARCHIVE
+      - INTELLIGENT_TIERING
       - STANDARD_IA
       - ONEZONE_IA
       - GLACIER


### PR DESCRIPTION
AWS recently added support for the following S3 storage classes:
* DEEP_ARCHIVE
* INTELLIGENT_TIERING

We add support for them to the sage provisioner.