### PR TITLE
[IT-567] Do not open port automatically

### DIFF
--- a/templates/managed-ec2-ubuntu-v2.j2
+++ b/templates/managed-ec2-ubuntu-v2.j2
@@ -225,7 +225,6 @@ Resources:
           GroupSet:
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
-            - !If [PublicEc2Resources, 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-BastianSecurityGroup', !Ref 'AWS::NoValue']
           {% if sceptre_user_data.OpenPorts is defined %}
             - !GetAtt InstanceSecurityGroup.GroupId
           {% endif %}

--- a/templates/managed-ec2-v9.j2
+++ b/templates/managed-ec2-v9.j2
@@ -224,7 +224,6 @@ Resources:
           GroupSet:
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
-            - !If [PublicEc2Resources, 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-BastianSecurityGroup', !Ref 'AWS::NoValue']
           {% if sceptre_user_data.OpenPorts is defined %}
             - !GetAtt InstanceSecurityGroup.GroupId
           {% endif %}

--- a/templates/managed-ec2-win-v3.j2
+++ b/templates/managed-ec2-win-v3.j2
@@ -242,7 +242,6 @@ Resources:
           GroupSet:
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
-            - !If [PublicEc2Resources, 'Fn::ImportValue': !Sub '${AWS::Region}-${VpcName}-BastianSecurityGroup', !Ref 'AWS::NoValue']
           {% if sceptre_user_data.OpenPorts is defined %}
             - !GetAtt InstanceSecurityGroup.GroupId
           {% endif %}


### PR DESCRIPTION
Before the provisioner allowed opening multiple ports to an EC2 we
had to enable the ssh port for public instances by default.  Now
that users can specify the exact ports to open we do not need
to open ports for public instances by default.