### PR TITLE
fix cfn-linter error

### DIFF
--- a/templates/managed-ebs.yaml
+++ b/templates/managed-ebs.yaml
@@ -13,7 +13,7 @@ Parameters:
     Type: String
   AvailabilityZone:
     Description: Availability Zone for the volume
-    Type: String
+    Type: "AWS::EC2::AvailabilityZone::Name"
     AllowedValues:
       - "us-east-1a"
       - "us-east-1b"


### PR DESCRIPTION
3.22s$ cfn-lint ./templates/**/*.yaml -i W1020
W2508 Availability Zone Parameter should be of type
[AWS::SSM::Parameter::Value<AWS::EC2::AvailabilityZone::Name>,
AWS::EC2::AvailabilityZone::Name] for Parameters/AvailabilityZone/Type
./templates/managed-ebs.yaml:16:5