### PR TITLE
[IT-569] Fix rotate credentials lambda

### DIFF
--- a/lambdas/rotate-credentials/template.yaml
+++ b/lambdas/rotate-credentials/template.yaml
@@ -46,7 +46,7 @@ Resources:
       Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
       Properties:
         Role: !GetAtt LambdaExecutionRole.Arn
-        Runtime: python3.6
+        Runtime: python2.7
         CodeUri: expire_access_key/
         Handler: app.lambda_handler
         Events:


### PR DESCRIPTION
Using python 3.6 to run the lambda results in error..

iterator should return strings, not bytes (did you open the file in text mode?): Error
Traceback (most recent call last):
File "/var/task/app.py", line 66, in lambda_handler
credential_report = get_credential_report()
File "/var/task/app.py", line 259, in get_credential_report
return get_credential_report()
File "/var/task/app.py", line 251, in get_credential_report
for row in reader:
File "/var/lang/lib/python3.6/csv.py", line 111, in __next__
self.fieldnames
File "/var/lang/lib/python3.6/csv.py", line 98, in fieldnames
self._fieldnames = next(self.reader)
_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)

This stackoverflow post indicates that it's due to python 3.x:
https://stackoverflow.com/questions/18897029/read-csv-file-from-url-into-python-3-x-csv-error-iterator-should-return-str/18897408

We switch to run with use python 2.7 instead.