### PR TITLE
Change the default grace period to rotate aws key

### DIFF
--- a/lambdas/rotate-credentials/template.yaml
+++ b/lambdas/rotate-credentials/template.yaml
@@ -8,7 +8,7 @@ Parameters:
   GracePeriod:
     Description: How many days to send the user a warning email before the lockout occurs
     Type: Number
-    Default: 14
+    Default: 7
   DisableKeys:
     Description: Set to True if you want to disabled expired IAM access keys
     Type: String


### PR DESCRIPTION
Nag email will be sent daily if users do not rotate their AWS key within the
grace period. Change it to default to a 7 day grace period because
14 days of nag emails is too annoying.