### PR TITLE
Fix issue with updating libssl

### DIFF
--- a/templates/managed-ec2-ubuntu-v3.j2
+++ b/templates/managed-ec2-ubuntu-v3.j2
@@ -244,6 +244,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
+          export DEBIAN_FRONTEND=noninteractive
           /usr/bin/apt-get update -y
           /usr/bin/apt-get install -y python-pip
           /usr/bin/apt-get install -y python-setuptools


### PR DESCRIPTION
When trying to install libssl1.1:amd64. Even if you pass apt `-y`, it
stops and prompts the user. One workaround is to
export `DEBIAN_FRONTEND=noninteractive`. Here is the confirmed
bug report: https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1832919