### PR TITLE
Fix lambda template

### DIFF
--- a/lambdas/rotate-credentials/template.yaml
+++ b/lambdas/rotate-credentials/template.yaml
@@ -132,7 +132,10 @@ Resources:
               - Effect: Allow
                 Action:
                   - sns:Publish
-                Resource: !ImportValue us-east-1-AccountAlertTopics-SNSAlertsInfoArn
+                Resource:
+                  - !ImportValue us-east-1-AccountAlertTopics-SNSAlertsInfoArn
+                  - !ImportValue us-east-1-AccountAlertTopics-SNSAlertsErrorArn
+                  - !ImportValue us-east-1-AccountAlertTopics-SNSAlertsCriticalArn
   ExpireAccessKeyFunctionFailureAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:


### PR DESCRIPTION
Fix error:
[2019-07-03 05:03:07] - prod/rotate-credentials ExpireAccessKeyFunction
AWS::Lambda::Function UPDATE_FAILED The provided execution role does not
have permissions to call Publish on SNS (Service: AWSLambdaInternal;
Status Code: 400; Error Code: InvalidParameterValueException;
Request ID: 54b11748-a347-4817-bc9f-73cde84c6792)

Fix by allowing sns:Publish to all topics.