### PR TITLE
Deploy on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ stages:
   - name: test
     if: branch = master AND type = push
   - name: deploy
-    if: branch = master AND type = push
+    if: type = push AND branch = master OR tag =~ /^v.*$/
 jobs:
   include:
     - stage: validate


### PR DESCRIPTION
The CI wasn't deploying when tags are created.  This will Make travis
deploy templates when a git tag is created so we can
get versioned template files.

deployments will goto S3 bucket:
s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/