### PR TITLE
Fix tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 python: 3.6
 cache: pip
 fast_finish: true
-branches:
-  only:
-  - master
 install:
   - pip install cfn-lint
   - pip install taskcat
@@ -18,7 +15,7 @@ stages:
   - name: test
     if: branch = master AND type = push
   - name: deploy
-    if: (tag IS present) OR (type = push AND branch = master)
+    if: (tag =~ ^v) OR (branch = master AND type = push)
 jobs:
   include:
     - stage: validate


### PR DESCRIPTION
Travis wasn't building tags due to the master branch restriction.
We don't need that restriction because it's already restricted
in stages section.