### PR TITLE
Fix service linked role definition

### DIFF
--- a/templates/service-linked-roles.yaml
+++ b/templates/service-linked-roles.yaml
@@ -8,31 +8,21 @@ Resources:
   # EC2 requires a special service-linked role named `AWSServiceRoleForEC2Spot` to launch and manage Spot Instances
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#service-linked-roles-spot-instance-requests
   AWSServiceRoleForEC2Spot:
-    Type: AWS::IAM::Role
+    Type: "AWS::IAM::ServiceLinkedRole"
     Properties:
-      RoleName: AWSServiceRoleForEC2Spot
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - spot.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: "/"
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/aws-service-role/AWSEC2SpotServiceRolePolicy
+      AWSServiceName: "spot.amazonaws.com"
+      Description: "SLR for EC2 Spot"
+  AWSServiceRoleForEC2SpotFleet:
+    Type: "AWS::IAM::ServiceLinkedRole"
+    Properties:
+      AWSServiceName: "spotfleet.amazonaws.com"
+      Description: "SLR for EC2 Spot Fleet"
 Outputs:
-  AWSServiceRoleForEC2SpotName:
+  AWSServiceRoleForEC2SpotId:
     Value: !Ref AWSServiceRoleForEC2Spot
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSServiceRoleForEC2SpotName'
-  AWSServiceRoleForEC2SpotArn:
-    Value: !GetAtt AWSServiceRoleForEC2Spot.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSServiceRoleForEC2SpotArn'
-  AWSServiceRoleForEC2SpotId:
-    Value: !GetAtt AWSServiceRoleForEC2Spot.RoleId
-    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSServiceRoleForEC2SpotId'
+  AWSServiceRoleForEC2SpotFleetId:
+    Value: !Ref AWSServiceRoleForEC2SpotFleet
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSServiceRoleForEC2SpotFleetId'


### PR DESCRIPTION
Creating service linked role with 'AWS::IAM::Role' does not work.  It
will result in the following error:

```
AWSServiceRoleForEC2Spot AWS::IAM::Role CREATE_FAILED Role name prefix AWSServiceRoleFor
can only be used for AWS Service Linked Roles (Service: AmazonIdentityManagement;
Status Code: 400; Error Code: InvalidInput; Request ID: f3d2bd8e-a71f-11e9-be23-5f82a06b6aba)
```

Cloudformation has a specific resource property for service linked roles
'AWS::IAM::ServiceLinkedRole'[1] which does work.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-servicelinkedrole.html#cfn-iam-servicelinkedrole-customsuffix