### PR TITLE
Remove tags for cloudtrail resource

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -155,13 +155,6 @@ Resources:
       EnableLogFileValidation: true
       IncludeGlobalServiceEvents: true
       IsMultiRegionTrail: true
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   # AWS Config service, https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/Config/Config.yaml
   AWSConfigConfigurationRecorder:
     Type: AWS::Config::ConfigurationRecorder


### PR DESCRIPTION
Adding tags for cloudtrail resource causes failure when updating
essentials.yaml against AWS logcentral account. Error is..

prod/essentials AWSCloudtrailTrail AWS::CloudTrail::Trail UPDATE_FAILED
Incorrect S3 bucket policy is detected for bucket: essentials-awss3cloudtrailbucket-1jz6pf8dzid7r
(Service: AWSCloudTrail; Status Code: 400; Error Code: InsufficientS3BucketPolicyException;
Request ID: aaa30197-f5c6-4a33-8982-017fcef6780f)

Removing tags allows updating the template without error.