### PR TITLE
fix cfn-lint error

### DIFF
--- a/templates/peer-route-config.yaml
+++ b/templates/peer-route-config.yaml
@@ -19,6 +19,7 @@ Parameters:
     Description: The CIDR of the VPN
     Type: String
     Default: "10.1.0.0/16"
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
 Resources:
   VpnPublicRoute:
     Type: "AWS::EC2::Route"

--- a/templates/peer-single-route.yaml
+++ b/templates/peer-single-route.yaml
@@ -16,6 +16,7 @@ Parameters:
     Description: The CIDR of the VPN
     Type: String
     Default: "10.1.0.0/16"
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
 Resources:
   VpnRoute:
     Type: "AWS::EC2::Route"


### PR DESCRIPTION
Add AllowPattern to CIDR parameters as suggested by cfn-lint

W2509 AllowedPattern and/or AllowedValues for Parameter should be specified at Parameters/VpnCidr.
Example for AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'