### PR TITLE
Template for Gateway VPC endpoints

### DIFF
--- a/templates/gateway-vpc-endpoint.yaml
+++ b/templates/gateway-vpc-endpoint.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Private connection between a VPC and a service
+Parameters:
+  VpcName:
+    Description: 'Name of an existing VPC'
+    Type: String
+  ServiceName:
+    Description: 'Name of an the AWS Service'
+    Type: String
+Resources:
+  GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+            Principal: "*"
+      RouteTableIds:
+        - !ImportValue {'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateRouteTable'}
+      ServiceName: !Ref ServiceName
+      VpcId: !ImportValue {'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'}
+Outputs:
+  GatewayEndpointId:
+    Description: VPC Gateway endpoint ID
+    Value: !Ref GatewayEndpoint
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-GatewayEndpointId'


### PR DESCRIPTION
Add a template to provision a Gateway VPC endpoint[1]. What an endpoint
effectively does is enable instances in your VPC to use their private
IP addresses to communicate with resources in other services.
Consequently, your instances do not require public IP addresses, and
you do not need an Internet Gateway, a NAT instance, or a virtual
private gateway in your VPC. This is because you use endpoint policies
to control access to resources in other services. Traffic between your
VPC and the AWS service does not leave the Amazon network which will
reduce latency and cost.

[1] https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html