### PR TITLE
[IT-418] fix cyclical dependency

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -13,6 +13,7 @@ Parameters:
     Description: The AWS account running the Sophos-VPN
     AllowedPattern: '[0-9]*'
     ConstraintDescription: Must be account number without dashes
+    Default: '745159704268'
   LambdaBucketVersioning:
     Type: String
     Description: Enabled to enable bucket versionsing, default is Suspended


### PR DESCRIPTION
Break cyclical dependency in cloudformation template by unmasking
the aws account id.  Also we make it a default so downstream
templates don't won't need to set this parameter at all.