### PR TITLE
[IT-666] remove CI group

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -40,14 +40,6 @@ Resources:
       UserName: !Ref AWSIAMTravisUser
   AWSIAMTravisUser:
     Type: 'AWS::IAM::User'
-    Properties:
-      Groups:
-        - !Ref AWSIAMCiGroup
-  AWSIAMCiGroup:
-    Type: 'AWS::IAM::Group'
-    Properties:
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess
   # Cloudformation bucket for CF templates
   AWSS3CloudformationBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
Our CI user, travis, does not need admin permissions.  Our CI system
is already setup to have travis assume the CfService role to deploy
templates.  For better security we revoke permissions from travis.