### PR TITLE
template to setup transit gateway attachments

### DIFF
--- a/templates/transit-gateway-attachment.yaml
+++ b/templates/transit-gateway-attachment.yaml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Setup an AWS transit gateway attachment
+Parameters:
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Platform'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Infrastructure'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+    Default: 'it@sagebase.org'
+  TransitGatewayId:
+    Description: 'The transit gateway Id'
+    Type: String
+    AllowedPattern: '^tgw-[a-z0-9]+$'
+    ConstraintDescription: 'Must be a transit gateway Id (i.e. tgw-1111148306e2d3b5)'
+    Default: 'tgw-03447748306e2d3b5'   # ID for sage-tgw transit gateway
+  VpcName:
+    Description: 'The transit gateway will attach to this VPC Id'
+    Type: String
+Resources:
+  TransitGatewayAttachment:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet2'
+      Tags:
+        - Key: Name
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+      TransitGatewayId: !Ref TransitGatewayId
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+
+Outputs:
+  TransitGatewayAttachment:
+    Description: This Is the transit gateway attachment
+    Value: !Ref TransitGatewayAttachment
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-TransitGatewayAttachment'


### PR DESCRIPTION
The workflow for setting up the transit gateway it to provision the
attachments on the spoke accounts of the "hub and spoke" model
therefore this template will be used to setup every hub to
spoke attachement (aka connections).

This depends on PR https://github.com/Sage-Bionetworks/transit-infra/pull/2