### PR TITLE
make TransitGatewayId a required parameter

### DIFF
--- a/templates/transit-gateway-attachment.yaml
+++ b/templates/transit-gateway-attachment.yaml
@@ -25,7 +25,6 @@ Parameters:
     Type: String
     AllowedPattern: '^tgw-[a-z0-9]+$'
     ConstraintDescription: 'Must be a transit gateway Id (i.e. tgw-1111148306e2d3b5)'
-    Default: 'tgw-03447748306e2d3b5'   # ID for sage-tgw transit gateway
   VpcName:
     Description: 'The transit gateway will attach to this VPC Id'
     Type: String


### PR DESCRIPTION
CFN updates for TGW will create a new TGW therefore it may change often.
Setting a default value makes less sense so we may users specify the
specific TGW.