### PR TITLE
Revert changes incompatible between taskcat v0.8 and v0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 3.6
 cache: pip
 fast_finish: true
 install:
-  - pip install cfn-lint taskcat
+  - pip install cfn-lint taskcat==0.8.50
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
@@ -29,7 +29,7 @@ jobs:
         - sam package --template-file lambdas/build/jumpcloud/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/jumpcloud.yaml
         - sam build --build-dir lambdas/build/rotate-credentials --base-dir lambdas/rotate-credentials --template lambdas/rotate-credentials/template.yaml
         - sam package --template-file lambdas/build/rotate-credentials/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/rotate-credentials.yaml
-        - cd ./ci && taskcat test run
+        - taskcat -c ci/taskcat.yml --tag owner=taskcat
     - stage: deploy
       script:
         - sam build --build-dir lambdas/build/jumpcloud --base-dir lambdas/jumpcloud --template lambdas/jumpcloud/template.yaml

--- a/ci/.taskcat.yml
+++ b/ci/.taskcat.yml
@@ -20,33 +20,33 @@ tests:
     parameter_input: sumologic-role-input.json
     regions:
       - us-east-1
-    template: sumologic-role.yaml
+    template: ../templates/sumologic-role.yaml
   ParkMyCloud:
     parameter_input: ParkMyCloud-input.json
     regions:
       - us-east-1
-    template: ParkMyCloud.yaml
+    template: ../templates/ParkMyCloud.yaml
   AccountAlertTopics:
     parameter_input: AccountAlertTopics-input.json
     regions:
       - us-east-1
-    template: AccountAlertTopics.yaml
+    template: ../templates/AccountAlertTopics.yaml
   jumpcloud:
     parameter_input: jumpcloud-input.json
     regions:
       - us-east-1
-    template: jumpcloud.yaml
+    template: ../templates/jumpcloud.yaml
   # test depends on resources in Sage-Bionetworks/admincentral-infra/config/prod/taskcat.yaml
   AddSameRegionBucketDownloadRestriction:
     parameter_input: AddSameRegionBucketDownloadRestriction-input.json
     regions:
       - us-east-1
-    template: AddSameRegionBucketDownloadRestriction.yaml
+    template: ../templates/AddSameRegionBucketDownloadRestriction.yaml
   bootstrap:
     parameter_input: bootstrap-input.json
     regions:
       - us-east-1
-    template: bootstrap.yaml
+    template: ../templates/bootstrap.yaml
   vpc:
     parameter_input: vpc-input.json
     regions:
@@ -56,7 +56,7 @@ tests:
     parameter_input: ec2-backup-input.json
     regions:
       - us-east-1
-    template: ec2-backup.yaml
+    template: ../templates/ec2-backup.yaml
 
   # Tests disabled due to issue: https://github.com/aws-quickstart/taskcat/issues/278
   #  s3-bucket:

--- a/ci/.taskcat.yml
+++ b/ci/.taskcat.yml
@@ -17,43 +17,43 @@ project:
     owner: "taskcat"
 tests:
   sumologic-role:
-    parameter_input: sumologic-role-input.json
+    parameter: sumologic-role-input.json
     regions:
       - us-east-1
     template: ../templates/sumologic-role.yaml
   ParkMyCloud:
-    parameter_input: ParkMyCloud-input.json
+    parameter: ParkMyCloud-input.json
     regions:
       - us-east-1
     template: ../templates/ParkMyCloud.yaml
   AccountAlertTopics:
-    parameter_input: AccountAlertTopics-input.json
+    parameter: AccountAlertTopics-input.json
     regions:
       - us-east-1
     template: ../templates/AccountAlertTopics.yaml
   jumpcloud:
-    parameter_input: jumpcloud-input.json
+    parameter: jumpcloud-input.json
     regions:
       - us-east-1
     template: ../templates/jumpcloud.yaml
   # test depends on resources in Sage-Bionetworks/admincentral-infra/config/prod/taskcat.yaml
   AddSameRegionBucketDownloadRestriction:
-    parameter_input: AddSameRegionBucketDownloadRestriction-input.json
+    parameter: AddSameRegionBucketDownloadRestriction-input.json
     regions:
       - us-east-1
     template: ../templates/AddSameRegionBucketDownloadRestriction.yaml
   bootstrap:
-    parameter_input: bootstrap-input.json
+    parameter: bootstrap-input.json
     regions:
       - us-east-1
     template: ../templates/bootstrap.yaml
   vpc:
-    parameter_input: vpc-input.json
+    parameter: vpc-input.json
     regions:
       - us-east-1
     template: vpc.yaml
   ec2-backup:
-    parameter_input: ec2-backup-input.json
+    parameter: ec2-backup-input.json
     regions:
       - us-east-1
     template: ../templates/ec2-backup.yaml

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -1,7 +1,8 @@
 ---
-project:
-  name: aws-infra
+global:
+  package-lambda: true
   owner: tcisagebio@sagebase.org
+  qsname: aws-infra
   regions:
     - ap-northeast-1
     - ap-northeast-2
@@ -13,50 +14,48 @@ project:
     - us-east-1
     - us-west-1
     - us-west-2
-  tags:
-    owner: "taskcat"
 tests:
   sumologic-role:
-    parameter: sumologic-role-input.json
+    parameter_input: sumologic-role-input.json
     regions:
       - us-east-1
-    template: ../templates/sumologic-role.yaml
+    template_file: sumologic-role.yaml
   ParkMyCloud:
-    parameter: ParkMyCloud-input.json
+    parameter_input: ParkMyCloud-input.json
     regions:
       - us-east-1
-    template: ../templates/ParkMyCloud.yaml
+    template_file: ParkMyCloud.yaml
   AccountAlertTopics:
-    parameter: AccountAlertTopics-input.json
+    parameter_input: AccountAlertTopics-input.json
     regions:
       - us-east-1
-    template: ../templates/AccountAlertTopics.yaml
+    template_file: AccountAlertTopics.yaml
   jumpcloud:
-    parameter: jumpcloud-input.json
+    parameter_input: jumpcloud-input.json
     regions:
       - us-east-1
-    template: ../templates/jumpcloud.yaml
+    template_file: jumpcloud.yaml
   # test depends on resources in Sage-Bionetworks/admincentral-infra/config/prod/taskcat.yaml
   AddSameRegionBucketDownloadRestriction:
-    parameter: AddSameRegionBucketDownloadRestriction-input.json
+    parameter_input: AddSameRegionBucketDownloadRestriction-input.json
     regions:
       - us-east-1
-    template: ../templates/AddSameRegionBucketDownloadRestriction.yaml
+    template_file: AddSameRegionBucketDownloadRestriction.yaml
   bootstrap:
-    parameter: bootstrap-input.json
+    parameter_input: bootstrap-input.json
     regions:
       - us-east-1
-    template: ../templates/bootstrap.yaml
+    template_file: bootstrap.yaml
   vpc:
-    parameter: vpc-input.json
+    parameter_input: vpc-input.json
     regions:
       - us-east-1
-    template: vpc.yaml
+    template_file: vpc.yaml
   ec2-backup:
-    parameter: ec2-backup-input.json
+    parameter_input: ec2-backup-input.json
     regions:
       - us-east-1
-    template: ../templates/ec2-backup.yaml
+    template_file: ec2-backup.yaml
 
   # Tests disabled due to issue: https://github.com/aws-quickstart/taskcat/issues/278
   #  s3-bucket:


### PR DESCRIPTION
Pin python package to v0.8 in order to allow parameter input to remain in separate json files