### PR TITLE
Add ssm role for lambda to bootstrap

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -106,6 +106,32 @@ Resources:
       Roles:
         -
           !Ref AWSIAMCfServiceRole
+  # This role is used by the SsmParam Lambda to read keys
+  AWSIAMSsmParamLambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+        - !Ref DecryptSecureKeysPolicy
+  DecryptSecureKeysPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DecryptSecureKmsKey
+            Effect: 'Allow'
+            Action: 'kms:Decrypt'
+            Resource: '*'
 Outputs:
   AWSIAMTravisUser:
     Value: !Ref AWSIAMTravisUser
@@ -127,3 +153,7 @@ Outputs:
     Value: !GetAtt AWSIAMCfServiceRole.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CfServiceRoleArn'
+  AWSIAMSsmParamLambdaExecutionRole:
+    Value: !GetAtt AWSIAMSsmParamLambdaExecutionRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SsmParamLambdaExecutionRole'

--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -107,6 +107,7 @@ Resources:
         -
           !Ref AWSIAMCfServiceRole
   # This role is used by the SsmParam Lambda to read keys
+  # See https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-ssm-param-macro
   AWSIAMSsmParamLambdaExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -153,7 +154,7 @@ Outputs:
     Value: !GetAtt AWSIAMCfServiceRole.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-CfServiceRoleArn'
-  AWSIAMSsmParamLambdaExecutionRole:
+  AWSIAMSsmParamLambdaExecutionRoleArn:
     Value: !GetAtt AWSIAMSsmParamLambdaExecutionRole.Arn
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-SsmParamLambdaExecutionRole'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SsmParamLambdaExecutionRoleArn'

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -342,6 +342,7 @@ Resources:
               AWS:
                 - !ImportValue us-east-1-bootstrap-TravisUserArn
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
+                - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRole
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -342,7 +342,7 @@ Resources:
               AWS:
                 - !ImportValue us-east-1-bootstrap-TravisUserArn
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
-                - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRole
+                - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRoleArn
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"


### PR DESCRIPTION
This is a proposal to move the role used for executing the SsmParam lambda to bootstrap.yaml and export it, then make it one of the principals that can use the AWSKmsInfraKey. Setting the principal on the KeyPolicy should not require an update of the Key itself. That's the first step. 
Step 2 is to set the SsmParam lambda to use this new role.

@zaro0508 what do you think?