### PR TITLE
Add root use of KMS

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -340,6 +340,11 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
+                - !Join
+                  - ''
+                  - - 'arn:aws:iam::'
+                    - !Ref AWS::AccountId
+                    - ':root'
                 - !ImportValue us-east-1-bootstrap-TravisUserArn
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRoleArn


### PR DESCRIPTION
This isn't a solution, but could be good to have root user access to KMS as an anti-lockout rule.