### PR TITLE
Fix typo in export name

### DIFF
--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -611,7 +611,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'BastianSecurityGroup']]
   QuarantineSecurityGroup:
     Description: "Quarantine Security Group Id"
-    Value: !Ref BastianSecurityGroup
+    Value: !Ref QuarantineSecurityGroup
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'QuarantineSecurityGroup']]


### PR DESCRIPTION
The prior PR didn't export the correct resource name