### PR TITLE
[SC-64] oidc identity provider custom resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
         - sam package --template-file lambdas/build/cfn-ssm-param-macro/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-ssm-param-macro.yaml
         - sam build --build-dir lambdas/build/cfn-s3objects-macro --base-dir lambdas/cfn-s3objects-macro --template lambdas/cfn-s3objects-macro/template.yaml
         - sam package --template-file lambdas/build/cfn-s3objects-macro/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-s3objects-macro.yaml
+        - aws cloudformation package --template-file lambdas/cfn-oidc-identity-provider/oidc_identity_provider.yml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-oidc-identity-provider.yaml
         - taskcat -c ci/taskcat.yml --tag owner=taskcat || travis_terminate 1
     - stage: deploy
       script:
@@ -52,4 +53,5 @@ jobs:
         - sam package --template-file lambdas/build/cfn-ssm-param-macro/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-ssm-param-macro.yaml
         - sam build --build-dir lambdas/build/cfn-s3objects-macro --base-dir lambdas/cfn-s3objects-macro --template lambdas/cfn-s3objects-macro/template.yaml
         - sam package --template-file lambdas/build/cfn-s3objects-macro/template.yaml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-s3objects-macro.yaml
+        - aws cloudformation package --template-file lambdas/cfn-oidc-identity-provider/oidc_identity_provider.yml --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw --output-template-file templates/cfn-oidc-identity-provider.yaml
         - ./deploy-templates.sh || travis_terminate 1

--- a/lambdas/cfn-oidc-identity-provider/Makefile
+++ b/lambdas/cfn-oidc-identity-provider/Makefile
@@ -1,0 +1,25 @@
+TEMPLATE_FILENAME	:= oidc_identity_provider.yml
+# S3_BUCKET			:=
+S3_PREFIX			:= oidc-identity-provider
+STACK_NAME			:= OIDCIdentityProvider
+URL					:= https://example.com/
+CLIENT_ID_LIST		:= id1,id2
+THUMBPRINT_LIST		:= 1234567890abcdef1234567890abcdef12345678,234567890abcdef1234567890abcdef123456789
+PARAMETERS			:= "Url=$(URL)" "ClientIDList=$(CLIENT_ID_LIST)" "ThumbprintList=$(THUMBPRINT_LIST)"
+
+# For example call
+# make S3_BUCKET=public.us-west-2.security.allizom.org deploy-cloudformation-stack
+
+ifndef S3_BUCKET
+$(error S3_BUCKET is not set)
+endif
+
+
+.PHONE: deploy-cloudformation-stack
+deploy-cloudformation-stack:
+	./deploy.sh \
+		"$(TEMPLATE_FILENAME)" \
+		"$(S3_BUCKET)" \
+		"$(S3_PREFIX)" \
+		"$(STACK_NAME)" \
+		"$(PARAMETERS)"

--- a/lambdas/cfn-oidc-identity-provider/README.md
+++ b/lambdas/cfn-oidc-identity-provider/README.md
@@ -1,0 +1,66 @@
+# OIDC Identity Provider CloudFormation Template Custom Resource
+
+Copied from [Mozilla security team](https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/oidc_identity_provider)
+
+This template and associated Lambda function and custom resource add support to \
+AWS CloudFormation for the [AWS IAM OpenId Connect Identity Provider][1]
+resource type.
+
+## Usage
+
+Launch the CloudFormation stack using the [`Makefile`](Makefile) by running a
+command like
+
+```shell script
+make S3_BUCKET=my-s3-bucket-name deploy-cloudformation-stack
+```
+
+This will launch the stack with example URL, Client IDs and Thumbprints.
+
+To pass your actual settings, either
+* Launch a stack from a hosted template of a specific git commit
+  ```
+  https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/oidc-identity-provider/5f48b78c87d98c18b55c98a6e5c285a80d53424c/oidc_identity_provider.5f48b78c87d98c18b55c98a6e5c285a80d53424c.yml
+  ```
+  * By pasting the S3 URL above into the AWS Web Console when creating a new
+    CloudFormation stack
+  * By using the AWS CLI with the S3 URL above to create a new CloudFormation
+    stack.
+    ```shell script
+    aws cloudformation create-stack \
+        --stack-name OIDCIdentityProvider \
+        --template-url https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/oidc-identity-provider/5f48b78c87d98c18b55c98a6e5c285a80d53424c/oidc_identity_provider.5f48b78c87d98c18b55c98a6e5c285a80d53424c.yml \
+        --capabilities CAPABILITY_IAM \
+        --parameters \
+            ParameterKey=Url,ParameterValue=https://example.com/ \
+            ParameterKey=ClientIDList,ParameterValue='id1\,id2' \
+            ParameterKey=ThumbprintList,ParameterValue='1234567890abcdef1234567890abcdef12345678\,234567890abcdef1234567890abcdef123456789'
+    ```
+* Host the Lambda code in your own S3 bucket by running `make` and passing in the values, for example
+  ```shell script
+  export S3_BUCKET=my-s3-bucket-name
+  export URL=https://example.com/
+  export CLIENT_ID_LIST=clientid1,clientid2
+  export THUMBPRINT_LIST=34567890abcdef1234567890abcdef1234567890,4567890abcdef1234567890abcdef1234567890a
+  make deploy-cloudformation-stack
+  ```
+* Edit the `Makefile` and set new defaults
+* Launch the stack with the defaults, then do a stack update and pass in the
+  real values either on the command line or in the web console
+
+## Why a separate Lambda file
+
+The code to handle creation updating and deletion of the OIDC Identity Provider
+couldn't fit into the [4096 characters][2] allowed for embedded code without
+heavily obfuscating the code.
+
+## Inspiration
+
+This project was inspired by the [cfn-identity-provider][3] by [Colin Panisset][4]
+of [Cevo][5] which provides a similar function but for the SAML identity provider
+
+[1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html
+[2]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-zipfile
+[3]: https://github.com/cevoaustralia/cfn-identity-provider
+[4]: https://github.com/nonspecialist
+[5]: https://cevo.com.au/

--- a/lambdas/cfn-oidc-identity-provider/deploy.sh
+++ b/lambdas/cfn-oidc-identity-provider/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+TEMPLATE_FILENAME=$1
+S3_BUCKET=$2
+S3_PREFIX=$3
+STACK_NAME=$4
+PARAMETERS=$5
+
+TARGET_PATH="`dirname \"${TEMPLATE_FILENAME}\"`"
+
+# This tempfile is required because of https://github.com/aws/aws-cli/issues/2504
+TMPFILE=$(mktemp --suffix .yaml)
+TMPDIR=$(mktemp --directory)
+ln --verbose --no-dereference --force --symbolic $TMPDIR "${TARGET_PATH}/build"
+trap "{ rm --verbose --force $TMPFILE;rm --force --recursive $TMPDIR;rm --verbose --force build; }" EXIT
+
+pip install --target "${TARGET_PATH}/build/" -r "${TARGET_PATH}/requirements.txt"
+cp --verbose "${TARGET_PATH}/"*.py "${TARGET_PATH}/build/"
+
+aws cloudformation package \
+  --template $TEMPLATE_FILENAME \
+  --s3-bucket $S3_BUCKET \
+  --s3-prefix $S3_PREFIX \
+  --output-template-file $TMPFILE
+
+if [ "$(aws cloudformation describe-stacks --query "length(Stacks[?StackName=='${STACK_NAME}'])")" = "1" ]; then
+  # Stack already exists, it will be updated
+  wait_verb=stack-update-complete
+else
+  # Stack doesn't exist it will be created
+  wait_verb=stack-create-complete
+fi
+
+aws cloudformation deploy --template-file $TMPFILE --stack-name $STACK_NAME \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides $PARAMETERS
+
+echo "Waiting for stack to reach a COMPLETE state"
+aws cloudformation wait $wait_verb --stack-name  $STACK_NAME

--- a/lambdas/cfn-oidc-identity-provider/oidc_identity_provider.py
+++ b/lambdas/cfn-oidc-identity-provider/oidc_identity_provider.py
@@ -1,0 +1,103 @@
+import boto3
+from crhelper import CfnResource
+from botocore.exceptions import ClientError
+
+helper = CfnResource(
+    json_logging=False, log_level='INFO', boto_level='CRITICAL')
+
+try:
+    iam = boto3.client("iam")
+    ARN_FORMAT = "arn:aws:iam::{}:oidc-provider/{}"
+except Exception as e:
+    helper.init_failure(e)
+
+
+def get_comma_delimited_list(event, parameter):
+    value = event['ResourceProperties'].get(parameter)
+    return [x.strip() for x in value.split(',')] if value else []
+
+
+def get_parameters(event):
+    aws_account_id = event['StackId'].split(':')[4]
+    url = event['ResourceProperties']['Url']
+    client_id_list = get_comma_delimited_list(event, 'ClientIDList')
+    thumbprint_list = get_comma_delimited_list(event, 'ThumbprintList')
+    return aws_account_id, url, client_id_list, thumbprint_list
+
+
+def update_provider(url, aws_account_id, client_id_list, thumbprint_list):
+    arn = ARN_FORMAT.format(aws_account_id, url[8:])
+    try:
+        response = iam.get_open_id_connect_provider(
+            OpenIDConnectProviderArn=arn)
+    except ClientError as e:
+        if e.response['Error']['Code'] == "NoSuchEntity":
+            response_create = iam.create_open_id_connect_provider(
+                Url=url,
+                ClientIDList=client_id_list,
+                ThumbprintList=thumbprint_list)
+            return response_create['OpenIDConnectProviderArn']
+        else:
+            raise
+    deleted_client_ids = set(response['ClientIDList']) - set(
+        client_id_list)
+    added_client_ids = set(client_id_list) - set(
+        response['ClientIDList'])
+    if set(thumbprint_list) ^ set(response['ThumbprintList']):
+        iam.update_open_id_connect_provider_thumbprint(
+            OpenIDConnectProviderArn=arn,
+            ThumbprintList=thumbprint_list)
+    for client_id in added_client_ids:
+        iam.add_client_id_to_open_id_connect_provider(
+            OpenIDConnectProviderArn=arn, ClientID=client_id)
+    for client_id in deleted_client_ids:
+        iam.remove_client_id_from_open_id_connect_provider(
+            OpenIDConnectProviderArn=arn, ClientID=client_id)
+    return arn
+
+
+def create_provider(aws_account_id, url, client_id_list, thumbprint_list):
+    try:
+        response = iam.create_open_id_connect_provider(
+            Url=url,
+            ClientIDList=client_id_list,
+            ThumbprintList=thumbprint_list)
+        return response['OpenIDConnectProviderArn']
+    except ClientError as e:
+        if e.response['Error']['Code'] == "EntityAlreadyExists":
+            arn = ARN_FORMAT.format(aws_account_id, url[8:])
+            return update_provider(url, aws_account_id, client_id_list, thumbprint_list)
+
+
+@helper.create
+def create(event, context):
+    return create_provider(*get_parameters(event))
+
+
+@helper.update
+def update(event, context):
+    aws_account_id, url, client_id_list, thumbprint_list = get_parameters(
+        event)
+    if (event['OldResourceProperties']['Url'] !=
+            event['ResourceProperties']['Url']):
+        arn = ARN_FORMAT.format(
+            aws_account_id, event['OldResourceProperties']['Url'][8:])
+        iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+        return create_provider(
+            aws_account_id, url, client_id_list, thumbprint_list)
+    else:
+        arn = ARN_FORMAT.format(
+            aws_account_id, event['ResourceProperties']['Url'][8:])
+        update_provider(url, aws_account_id, client_id_list, thumbprint_list)
+
+
+@helper.delete
+def delete(event, context):
+    aws_account_id, _, _, _ = get_parameters(event)
+    arn = ARN_FORMAT.format(
+        aws_account_id, event['ResourceProperties']['Url'][8:])
+    iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+
+
+def lambda_handler(event, context):
+    helper(event, context)

--- a/lambdas/cfn-oidc-identity-provider/oidc_identity_provider.yml
+++ b/lambdas/cfn-oidc-identity-provider/oidc_identity_provider.yml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: OIDC identity provider
+Metadata:
+  Source: https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/oidc_identity_provider/
+Parameters:
+  Url:
+    Type: String
+    Description: The URL of the identity provider. The URL must begin with https:// and should correspond to the iss claim in the provider's OpenID Connect ID tokens
+    AllowedPattern: https://.*
+    ConstraintDescription: The URL must begin with https://
+  ClientIDList:
+    Type: String
+    Description: A comma delimited list of client IDs (also known as audiences)
+  ThumbprintList:
+    Type: String
+    Description: A comma delimited list list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificates (also known as CA Thumbprints)
+Resources:
+  IdentityProvider:
+    Type: Custom::IdentityProvider
+    Properties:
+      ServiceToken: !GetAtt IdentityProviderCreatorFunction.Arn
+      Region: !Ref "AWS::Region"
+      Url: !Ref Url
+      ClientIDList: !Ref ClientIDList
+      ThumbprintList: !Ref ThumbprintList
+  IdentityProviderCreatorFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.7
+      Handler: oidc_identity_provider.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt IdentityProviderCreatorRole.Arn
+      Timeout: 30
+      Code: ./
+  IdentityProviderCreatorRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: ManageOIDCProvider
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:GetOpenIDConnectProvider
+                  - iam:CreateOpenIDConnectProvider
+                  - iam:AddClientIDToOpenIDConnectProvider
+                  - iam:RemoveClientIDFromOpenIDConnectProvider
+                  - iam:UpdateOpenIDConnectProviderThumbprint
+                  - iam:DeleteOpenIDConnectProvider
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"

--- a/lambdas/cfn-oidc-identity-provider/requirements.txt
+++ b/lambdas/cfn-oidc-identity-provider/requirements.txt
@@ -1,0 +1,1 @@
+crhelper


### PR DESCRIPTION
Package and deploy a cloudformation oidc identity provier custom
resource to our shared S3 lambda bucket.  It will be used to automate
deployments of oidc identity provider resources on our AWS
accounts.

This custom resource was copied from the Mozilla security team[1]

[1] https://github.com/mozilla/security/tree/master/operations/cloudformation-templates/oidc_identity_provider