### PR TITLE
Add scheduled maintenance tasks and add managed policy to instance profile

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -179,38 +179,6 @@ Resources:
           Value: !Ref Project
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail
-  AWSS3SSMTasklogBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
-  AWSSSMTaskNotificationSNSTopic:
-    Type: "AWS::SNS::Topic"
-    Properties:
-      Subscription:
-        -
-          Endpoint: !Ref OperatorEmail
-          Protocol: email
-  AWSSSMTaskNotificationSNSTopicPolicy:
-    Type: "AWS::SNS::TopicPolicy"
-    Properties:
-      Topics:
-        - !Ref AWSSSMTaskNotificationSNSTopic
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Sid: "SSMTaskNotificaitonSNSTopicPolicy"
-            Effect: "Allow"
-            Principal:
-              Service: "ssm.amazonaws.com"
-            Resource: "*"
-            Action: "SNS:Publish"
   # Bucket for lambda artifacts
   AWSS3LambdaArtifactsBucket:
     Type: AWS::S3::Bucket
@@ -503,18 +471,6 @@ Outputs:
     Value: !GetAtt AWSS3ConfigBucket.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-AwsConfigBucketArn'
-  AWSS3SSMTasklogBucket:
-    Value: !Ref AWSS3SSMTasklogBucket
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTasklogS3Bucket'
-  AWSS3SSMTasklogBucketArn:
-    Value: !GetAtt AWSS3SSMTasklogBucket.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTasklogS3BucketArn'
-  AWSSSMTaskNotificationSNSTopic:
-    Value: !Ref AWSSSMTaskNotificationSNSTopic
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTaskNotificationTopic'
   AWSS3LambdaArtifactsBucket:
     Value: !Ref AWSS3LambdaArtifactsBucket
     Export:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -363,6 +363,24 @@ Resources:
           - !Ref AWS::StackName
           - '/InfraKey'
       TargetKeyId: !Ref AWSKmsInfraKey
+
+  # Allow SSM service to connect to agents on instance
+  SystemManagementRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "ssm.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore']
+  
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -392,12 +410,14 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - !Ref TagRootVolumePolicy
+# This profile would more accurately be named "EC2ManagementProfile"
   TagRootVolumeProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
       Path: "/"
       Roles:
         - !Ref TagRootVolumeRole
+        - !Ref SystemManagementRole
   # Role for Data Lifecycle Manager (DLM)
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html
   AWSDataLifecycleManagerDefaultRole:
@@ -467,7 +487,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-InfraKeyAlias'
   TagRootVolumeProfile:
-    Description: Profile to allow instances to tag its root volume
+    Description: Profile to allow instances to tag its root volume and allow SSM actions
     Value: !Ref TagRootVolumeProfile
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-TagRootVolumeProfile'

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -503,12 +503,12 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceProfileArn'
   ManagedInstanceRole:
-    Description: Role to allow instances to tag its root volume
+    Description: Role to allow instances to tag its root volume and allow SSM actions
     Value: !Ref ManagedInstanceRole
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceRole'
   ManagedInstanceRoleArn:
-    Description: Role to allow instances to tag its root volume
+    Description: Role to allow instances to tag its root volume and allow SSM actions
     Value: !GetAtt ManagedInstanceRole.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceRoleArn'

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -413,8 +413,6 @@ Resources:
             Principal:
               Service:
                 - "ec2.amazonaws.com"
-                #Needed for SSM management
-                - "ssm.amazonaws.com"
             Action:
               - "sts:AssumeRole"
       Path: "/"

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -364,6 +364,31 @@ Resources:
           - '/InfraKey'
       TargetKeyId: !Ref AWSKmsInfraKey
 
+  # Allow instances to apply tags to its root volume and attach SSM
+  ManagedEC2Role:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+                - "ssm.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - !Ref TagRootVolumePolicy
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+  ManagedEC2Profile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: "/"
+      Roles:
+        - !Ref ManagedEC2Role
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -395,9 +420,6 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - !Ref TagRootVolumePolicy
-          #Add policy to role allow SSM to attach to instances
-        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
-# This profile would more accurately be named "EC2ManagementProfile"
   TagRootVolumeProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -472,8 +494,18 @@ Outputs:
     Value: !Ref AWSKmsInfraKeyAlias
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-InfraKeyAlias'
-  TagRootVolumeProfile:
+  ManagedEC2Profile:
     Description: Profile to allow instances to tag its root volume and allow SSM actions
+    Value: !Ref ManagedEC2Profile
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedEC2Profile'
+  ManagedEC2Role:
+    Description: Role to allow instances to tag its root volume
+    Value: !Ref ManagedEC2Role
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedEC2Role'
+  TagRootVolumeProfile:
+    Description: Profile to allow instances to tag its root volume
     Value: !Ref TagRootVolumeProfile
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-TagRootVolumeProfile'

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -365,7 +365,7 @@ Resources:
       TargetKeyId: !Ref AWSKmsInfraKey
 
   # Allow instances to apply tags to its root volume and attach SSM
-  ManagedEC2Role:
+  ManagedInstanceRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
@@ -383,12 +383,12 @@ Resources:
       ManagedPolicyArns:
         - !Ref TagRootVolumePolicy
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
-  ManagedEC2Profile:
+  ManagedInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
       Path: "/"
       Roles:
-        - !Ref ManagedEC2Role
+        - !Ref ManagedInstanceRole
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -492,16 +492,16 @@ Outputs:
     Value: !Ref AWSKmsInfraKeyAlias
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-InfraKeyAlias'
-  ManagedEC2Profile:
+  ManagedInstanceProfile:
     Description: Profile to allow instances to tag its root volume and allow SSM actions
-    Value: !Ref ManagedEC2Profile
+    Value: !Ref ManagedInstanceProfile
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedEC2Profile'
-  ManagedEC2Role:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceProfile'
+  ManagedInstanceRole:
     Description: Role to allow instances to tag its root volume
-    Value: !Ref ManagedEC2Role
+    Value: !Ref ManagedInstanceRole
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedEC2Role'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceRole'
   TagRootVolumeProfile:
     Description: Profile to allow instances to tag its root volume
     Value: !Ref TagRootVolumeProfile

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -364,23 +364,6 @@ Resources:
           - '/InfraKey'
       TargetKeyId: !Ref AWSKmsInfraKey
 
-  # Allow SSM service to connect to agents on instance
-  SystemManagementRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: "Allow"
-            Principal:
-              Service:
-                - "ssm.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore']
-  
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -405,11 +388,15 @@ Resources:
             Principal:
               Service:
                 - "ec2.amazonaws.com"
+                #Needed for SSM management
+                - "ssm.amazonaws.com"
             Action:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
         - !Ref TagRootVolumePolicy
+          #Add policy to role allow SSM to attach to instances
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
 # This profile would more accurately be named "EC2ManagementProfile"
   TagRootVolumeProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -417,7 +404,6 @@ Resources:
       Path: "/"
       Roles:
         - !Ref TagRootVolumeRole
-        - !Ref SystemManagementRole
   # Role for Data Lifecycle Manager (DLM)
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html
   AWSDataLifecycleManagerDefaultRole:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -179,6 +179,38 @@ Resources:
           Value: !Ref Project
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail
+  AWSS3SSMTasklogBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  AWSSSMTaskNotificationSNSTopic:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      Subscription:
+        -
+          Endpoint: !Ref OperatorEmail
+          Protocol: email
+  AWSSSMTaskNotificationSNSTopicPolicy:
+    Type: "AWS::SNS::TopicPolicy"
+    Properties:
+      Topics:
+        - !Ref AWSSSMTaskNotificationSNSTopic
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "SSMTaskNotificaitonSNSTopicPolicy"
+            Effect: "Allow"
+            Principal:
+              Service: "ssm.amazonaws.com"
+            Resource: "*"
+            Action: "SNS:Publish"
   # Bucket for lambda artifacts
   AWSS3LambdaArtifactsBucket:
     Type: AWS::S3::Bucket
@@ -471,6 +503,18 @@ Outputs:
     Value: !GetAtt AWSS3ConfigBucket.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-AwsConfigBucketArn'
+  AWSS3SSMTasklogBucket:
+    Value: !Ref AWSS3SSMTasklogBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTasklogS3Bucket'
+  AWSS3SSMTasklogBucketArn:
+    Value: !GetAtt AWSS3SSMTasklogBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTasklogS3BucketArn'
+  AWSSSMTaskNotificationSNSTopic:
+    Value: !Ref AWSSSMTaskNotificationSNSTopic
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SSMTaskNotificationTopic'
   AWSS3LambdaArtifactsBucket:
     Value: !Ref AWSS3LambdaArtifactsBucket
     Export:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -541,11 +541,21 @@ Outputs:
     Value: !Ref ManagedInstanceProfile
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceProfile'
+  ManagedInstanceProfileArn:
+    Description: Profile to allow instances to tag its root volume and allow SSM actions
+    Value: !GetAtt ManagedInstanceProfile.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceProfileArn'
   ManagedInstanceRole:
     Description: Role to allow instances to tag its root volume
     Value: !Ref ManagedInstanceRole
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceRole'
+  ManagedInstanceRoleArn:
+    Description: Role to allow instances to tag its root volume
+    Value: !GetAtt ManagedInstanceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ManagedInstanceRoleArn'
   TagRootVolumeProfile:
     Description: Profile to allow instances to tag its root volume
     Value: !Ref TagRootVolumeProfile

--- a/templates/maintenance.yaml
+++ b/templates/maintenance.yaml
@@ -1,0 +1,89 @@
+Description: Maintenance tasks for scipoolprod instances
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  DefaultMaintenanceWindow:
+    Type: 'AWS::SSM::MaintenanceWindow'
+    Properties:
+      Description: Automated deliver patches every other Sunday
+      Duration: 3
+      Cutoff: 1
+      Schedule: 'cron(00 10 ? * SUN/2 *)' #1000UTC Every other Sunday
+      ScheduleTimezone: 'UTC'
+      AllowUnassociatedTargets: false
+  DefaultPatchGroupTarget:
+    Type: 'AWS::SSM::MaintenanceWindowTarget'
+    Properties:
+      Description: "Instances tagged PatchGroup=prod-default"
+      ResourceType: INSTANCE
+      WindowId:
+        Ref: DefaultMaintenanceWindow
+      Targets:
+        - Key: 'tag:PatchGroup'
+          Values:
+            - 'prod-default'  #Current we have only one group
+  ManagedInstanceMaintenanceTarget:
+    Type: 'AWS::SSM::MaintenanceWindowTarget'
+    Properties:
+      Description: "Instances tagged ManagedInstanceMaintenanceTarget=yes"
+      ResourceType: INSTANCE
+      WindowId:
+        Ref: DefaultMaintenanceWindow
+      Targets:
+        - Key: 'tag:ManagedInstanceMaintenanceTarget'
+          Values:
+            - 'yes'
+  MaintenanceWindowRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+  MaintenanceWindowAgentUpdateTask:
+    Type: 'AWS::SSM::MaintenanceWindowTask'
+    Properties:
+      Description: AWS-UpdateSSMAgent task run during DefaultMaintenanceWindow
+      ServiceRoleArn: !GetAtt MaintenanceWindowRole.Arn
+      Priority: 1
+      MaxErrors: '1'
+      MaxConcurrency: '2'
+      Targets:
+        - Key: WindowTargetIds
+          Values:
+            - Ref: ManagedInstanceMaintenanceTarget
+      TaskType: RUN_COMMAND
+      WindowId:
+        Ref: DefaultMaintenanceWindow
+      TaskArn: AWS-UpdateSSMAgent
+  MaintenanceWindowPatchTask:
+    Type: 'AWS::SSM::MaintenanceWindowTask'
+    Properties:
+      Description: AWS-RunPatchBaseline task run during DefaultMaintenanceWindow
+      ServiceRoleArn: !GetAtt MaintenanceWindowRole.Arn
+      Priority: 2
+      MaxErrors: '1'
+      MaxConcurrency: '2'
+      Targets:
+        - Key: WindowTargetIds
+          Values:
+            - Ref: DefaultPatchGroupTarget
+      TaskType: RUN_COMMAND
+      WindowId:
+        Ref: DefaultMaintenanceWindow
+      TaskArn: AWS-RunPatchBaseline #Operate with default managed baselines
+      TaskInvocationParameters:
+        MaintenanceWindowRunCommandParameters:
+          Parameters:
+            Operation:
+              - Install
+            RebootOption:
+              - RebootIfNeeded

--- a/templates/maintenance.yaml
+++ b/templates/maintenance.yaml
@@ -4,6 +4,7 @@ Resources:
   DefaultMaintenanceWindow:
     Type: 'AWS::SSM::MaintenanceWindow'
     Properties:
+      Name: ProdDefaultMaintenanceWindow
       Description: Automated deliver patches every other Sunday
       Duration: 3
       Cutoff: 1


### PR DESCRIPTION
The objective is to create a maintenance routine that operates on a cron schedule to run two tasks against EC2s with specific tags on them. The first task is to update the SSM agent on the instance;
the second is to run the AWS default patch baseline task.

This would schedule only one maintenance window: 10 am UTC every other Sunday, to run for 3 hours and reboot if needed

Depends:

Adding SSM policy to instance profiles of instances generated through SC: Sage-Bionetworks/scipoolprod-sc-lib-infra#106
Add instance profile option for instances not created in SC (not related to SC-12):
Sage-Bionetworks/aws-infra#233