### PR TITLE
[SYNPY-1054] Allow all S3 VPC Endpoints to access same region restricted S3 Buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ AWS Admincentral account.  The purpose is to allow us to share those templates.
 
 ## Deployments
 Templates can be deployed using the AWSCLI.  We use [sceptre](https://github.com/cloudreach/sceptre)
-for more functionality.  Examples of deployments of templats in this repo
+for more functionality.  Examples of deployments of templates in this repo
 can be found in our other Sage-Bionetworks/*-infa repos
 (i.e. [sandbox-infra](https://github.com/Sage-Bionetworks/sandbox-infra))
 

--- a/ci/AddSameRegionBucketDownloadRestriction-input.json
+++ b/ci/AddSameRegionBucketDownloadRestriction-input.json
@@ -2,9 +2,5 @@
     {
         "ParameterKey": "BucketName",
         "ParameterValue": "taskcat-tastcatsynapsebucket-oeg42xg2hitp"
-    },
-    {
-        "ParameterKey": "SameRegionResourceAccessToBucketGrantVpcAccess",
-        "ParameterValue": "vpc-26976a5d"
     }
 ]

--- a/templates/AddSameRegionBucketDownloadRestriction.yaml
+++ b/templates/AddSameRegionBucketDownloadRestriction.yaml
@@ -27,12 +27,6 @@ Parameters:
     AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
     Default: 'it@sagebase.org'
-  # This lambda, by default, restricts access to buckets when Gateway VPC Endpoints are enabled on an AWS account
-  # This parameter overrides that by explicitly granting bucket access to resources in this list of VPCs.
-  SameRegionResourceAccessToBucketGrantVpcAccess:
-    Type: CommaDelimitedList
-    Description: Allow resources in a VPC (i.e. ["vpc-111bbb22", "vpc-123add45"]) to access the bucket
-    ConstraintDescription: Comma separated list of VPC IDs (i.e. ["vpc-111bbb22", "vpc-123add45"])
 Resources:
   ExternalBucketGroupPolicyUpdateRole:
     Type: "AWS::IAM::Role"
@@ -76,7 +70,6 @@ Resources:
       Environment:
         Variables:
           BUCKET_NAME: !Ref "BucketName"
-          VPC_IDS: !Join [ ",", !Ref "SameRegionResourceAccessToBucketGrantVpcAccess"]
           REGION: !Ref "AWS::Region"
       Code:
         ZipFile: |
@@ -95,14 +88,11 @@ Resources:
           region = os.environ['REGION']
           policy_statement_id="DenyGetObjectForNonMatchingIp"
 
-
           # have to put in a not None value for repsonseData or error will be thrown
           custom_resource_response_data = {'Data':''}
 
           def handler(event, context):
             try:
-
-              vpc_ids = [x.strip() for x in str.split(os.environ.get('VPC_IDS', '[]'), sep=',') if x.strip()]
 
               #for the case when this lambda is triggered by aws custom resource
               custom_resource_request_type = event.get('RequestType')
@@ -130,12 +120,11 @@ Resources:
                                            'Action': 's3:GetObject',
                                            'Resource': 'arn:aws:s3:::'+bucket_name+'/*',
                                            'Condition': {'NotIpAddress': {'aws:SourceIp': region_ip_addresses}}}
-                if vpc_ids:
-                  # allows listed VPCs to bypass the ip restriction
-                  new_ip_policy_statement['Condition']['StringNotEquals']={ 'aws:sourceVpc': vpc_ids }
-                else:
-                  # remove existing vpc condition if it exists
-                  new_ip_policy_statement['Condition'].pop('StringNotEquals', {})
+
+                # allows any S3 VPC Endpoint to bypass the ip restriction.
+                # cross region gateway endpoints are not supported in AWS so any S3 VPC endpoint
+                # traffic is implicitly same region.
+                new_ip_policy_statement['Condition']['Null']={ 'aws:sourceVpc': 'true' }
 
                 #add new IP address policy statement
                 bucket_policy['Statement'].append(new_ip_policy_statement)

--- a/templates/s3-bucket.yaml
+++ b/templates/s3-bucket.yaml
@@ -26,12 +26,6 @@ Parameters:
       - true
       - false
     Default: false
-  # only used with SameRegionResourceAccessToBucket, more info in AddSameRegionBucketDownloadRestriction.yaml
-  SameRegionResourceAccessToBucketGrantVpcAccess:
-    Type: String
-    Default: "[]"
-    Description: Grant bucket access to VPC endpoints (only used with SameRegionResourceAccessToBucket)
-    ConstraintDescription: Comma separated list of VPC IDs (i.e. ["vpc-111bbb22", "vpc-1a2b3c4d5e"])
   BucketVersioning:
     Type: String
     Description: Enabled to enable bucket versionsing, default is Suspended
@@ -203,7 +197,6 @@ Resources:
       TemplateURL: 'https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/v0.1.0/AddSameRegionBucketDownloadRestriction.yaml'
       Parameters:
         BucketName: !If [EnableEncryption, !Ref SynapseEncryptedExternalBucket, !Ref SynapseExternalBucket]
-        SameRegionResourceAccessToBucketGrantVpcAccess: !Ref SameRegionResourceAccessToBucketGrantVpcAccess
       Tags:
         - Key: "Name"
           Value: !Ref 'AWS::StackName'


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNPY-1054

A user in a different VPC in us-east-1 with a configured S3 VPC Endpoint Gateway is being denied access to the amp-mayo-sinai-synapseencryptedexternalbucket-1bmvn8rlwixv2 S3 bucket.

This is a modification of the behavior for [IT-661](https://github.com/Sage-Bionetworks/aws-infra/pull/173) which allowed access specifically via the S3 VPC Endpoint for the Sage computevpc.

S3 VPC Endpoints only support intra-region traffic and any S3 traffic with an aws:sourceVpc is implicitly from the same region. This changes the behavior of the region block to allow any VPC endpoint sourced request, not just a list of explicitly defined VPCs. Originally I had thought to further parameterize SameRegionResourceAccessToBucket, but I can't think of a case where we'd want to allow requests from all a region's public IPs but only allow a subset of private VPC traffic from that region so this removes the existing parameterization in favor of a general VPC endpoint permission.

https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html
> Endpoints are supported within the same Region only. You cannot create an endpoint between a VPC and a service in a different Region.
> other internet traffic goes to your internet gateway, including traffic that's destined for other services, **and destined for the AWS service in other Regions**