### PR TITLE
Allow calling Get-Role to ManagedInstanceProfile

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -400,7 +400,7 @@ Resources:
             Effect: Allow
             Action:
               - "iam:GetRole"
-            Resource: !Sub 'arn:aws:sts:${AWS::Region}:${AWS::AccountId}:assumed-role/*'
+            Resource: "*"
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -382,6 +382,7 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - !Ref TagRootVolumePolicy
+        - !Ref ReadAssumedRoleInformationPolicy
         - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
   ManagedInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -389,6 +390,17 @@ Resources:
       Path: "/"
       Roles:
         - !Ref ManagedInstanceRole
+  ReadAssumedRoleInformationPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ReadAssumedRoleInformation
+            Effect: Allow
+            Action:
+              - "iam:GetRole"
+            Resource: !Sub 'arn:aws:sts:${AWS::Region}:${AWS::AccountId}:assumed-role/*'
   # Allow instances to apply tags to its root volume
   TagRootVolumePolicy:
     Type: "AWS::IAM::ManagedPolicy"
@@ -401,7 +413,7 @@ Resources:
             Action:
               - "ec2:Describe*"
               - "ec2:CreateTags"
-            Resource: "*"
+            Resource: "*" 
   TagRootVolumeRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -413,7 +413,7 @@ Resources:
             Action:
               - "ec2:Describe*"
               - "ec2:CreateTags"
-            Resource: "*" 
+            Resource: "*"
   TagRootVolumeRole:
     Type: "AWS::IAM::Role"
     Properties:


### PR DESCRIPTION
Adding this policy to the ManagedInstanceProfile allows instances to query for the roleid of assumed role users so they can add the roleid to a tag on themselves. This is needed for the SSM StartSession connection filter that restricts access to specific roleid/sessionname strings. I've changed this PR to allow reading role on any string, "*", because the rolename could have any pattern.

Merging this PR might destructively change instances with the ManagedInstance Profile, which should be limited to Service Catalog instances.  
Passes pre-commit