### PR TITLE
Add port 80 ingress to allow rewrite rule to work

### DIFF
--- a/templates/managed-alb-https-v2.yaml
+++ b/templates/managed-alb-https-v2.yaml
@@ -129,6 +129,10 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
       Tags:
         - Key: "Department"
           Value: !Ref Department


### PR DESCRIPTION
This is a minor change the new ALB... We have a rewrite rule for HTTP->HTTPS, but the security group on the ALB doesn't currently allow 80 inbound