### PR TITLE
Define mini VPC template with small subnets

### DIFF
--- a/templates/vpc-mini.yaml
+++ b/templates/vpc-mini.yaml
@@ -8,7 +8,7 @@ Parameters:
   VpcSubnetPrefix:
     Description: The VPC subnet prefix (i.e. 10.255.40)
     Type: String
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9]    {2}|2[0-4][0-9]|25[0-5])$
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
   PublicSubnetZones:
     Description: Availability zones for public subnets
     Type: List<AWS::EC2::AvailabilityZone::Name>

--- a/templates/vpc-mini.yaml
+++ b/templates/vpc-mini.yaml
@@ -40,7 +40,7 @@ Mappings:
     Public2:
       CIDR: "160/28" #10.255.X.160-175
     Private2:
-      CIDR: "176/26" #10.255.X.176-240
+      CIDR: "176/26" #10.255.X.176-239
 Resources:
   VPC:
     Type: "AWS::EC2::VPC"

--- a/templates/vpc-mini.yaml
+++ b/templates/vpc-mini.yaml
@@ -8,6 +8,7 @@ Parameters:
   VpcSubnetPrefix:
     Description: The VPC subnet prefix (i.e. 10.255.40)
     Type: String
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9]    {2}|2[0-4][0-9]|25[0-5])$
   PublicSubnetZones:
     Description: Availability zones for public subnets
     Type: List<AWS::EC2::AvailabilityZone::Name>
@@ -24,24 +25,6 @@ Parameters:
     Default: "10.1.0.0/16"
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
 Mappings:
   SubnetConfig:
     VPC:
@@ -69,19 +52,8 @@ Resources:
         - - !Ref VpcSubnetPrefix
           - !FindInMap [SubnetConfig, VPC, CIDR]
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public, Public1, Public2, Private, Private1, Private2"
         - Key: "Name"
           Value: !Ref VpcName
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -95,19 +67,8 @@ Resources:
         - 0
         - !Ref PublicSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -120,19 +81,8 @@ Resources:
         - 0
         - !Ref PrivateSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Private"
         - Key: "Name"
           Value: "Private"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -146,19 +96,8 @@ Resources:
         - 1
         - !Ref PublicSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public1"
         - Key: "Name"
           Value: "Public1"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet2:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -172,19 +111,8 @@ Resources:
         - 2
         - !Ref PublicSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public2"
         - Key: "Name"
           Value: "Public2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -197,19 +125,8 @@ Resources:
         - 1
         - !Ref PrivateSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Private1"
         - Key: "Name"
           Value: "Private1"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet2:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -222,36 +139,14 @@ Resources:
         - 2
         - !Ref PrivateSubnetZones
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Private2"
         - Key: "Name"
           Value: "Private2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   InternetGateway:
     Type: "AWS::EC2::InternetGateway"
     Properties:
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public, Public1, Public2"
         - Key: "Name"
           Value: "Public, Public1, Public2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   GatewayToInternet:
     Type: "AWS::EC2::VPCGatewayAttachment"
     Properties:
@@ -265,19 +160,8 @@ Resources:
       VpcId:
         Ref: "VPC"
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicRoute:
     Type: "AWS::EC2::Route"
     DependsOn: "GatewayToInternet"
@@ -314,19 +198,8 @@ Resources:
       VpcId:
         Ref: "VPC"
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   InboundHTTPPublicNetworkAclEntry:
     Type: "AWS::EC2::NetworkAclEntry"
     Properties:
@@ -383,16 +256,6 @@ Resources:
           - "AllocationId"
       SubnetId:
          Ref: "PublicSubnet"
-      Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElasticIP:
     Type: "AWS::EC2::EIP"
     Properties:
@@ -403,19 +266,8 @@ Resources:
       VpcId:
         Ref: "VPC"
       Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Network"
-          Value: "Private"
         - Key: "Name"
           Value: "Private"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateRouteToInternet:
     Type: "AWS::EC2::Route"
     Properties:
@@ -464,16 +316,6 @@ Resources:
           FromPort: -1
           ToPort: -1
           IpProtocol: "-1"
-      Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -492,16 +334,6 @@ Resources:
           FromPort: -1
           ToPort: -1
           IpProtocol: "-1"
-      Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   QuarantineSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -522,16 +354,6 @@ Resources:
       SecurityGroupEgress:
         - CidrIp: "127.0.0.1/32"
           IpProtocol: "-1"
-      Tags:
-        - Key: "Application"
-          Value:
-            Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 Outputs:
   VPCId:
     Description: "VPCId of the newly created VPC"

--- a/templates/vpc-mini.yaml
+++ b/templates/vpc-mini.yaml
@@ -1,0 +1,628 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Creates a VPC with public and private subnets and a managed NAT gateway.
+Parameters:
+  VpcName:
+    Description: The VPC name (i.e. Synapse-Prod)
+    Type: String
+  VpcSubnetPrefix:
+    Description: The VPC subnet prefix (i.e. 10.255.40)
+    Type: String
+  PublicSubnetZones:
+    Description: Availability zones for public subnets
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+    ConstraintDescription: List of Availability Zones in a region, such as us-east-1a, us-east-1b, us-east-1c
+    Default: "us-east-1a, us-east-1b, us-east-1c"
+  PrivateSubnetZones:
+    Description: Availability zones for private subnets
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+    ConstraintDescription: List of Availability Zones in a region, such as us-east-1a, us-east-1b, us-east-1c
+    Default: "us-east-1a, us-east-1b, us-east-1c"
+  VpnCidr:
+    Description: CIDR of the (sophos-utm) VPN
+    Type: String
+    Default: "10.1.0.0/16"
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Platform'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Infrastructure'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+    Default: 'it@sagebase.org'
+Mappings:
+  SubnetConfig:
+    VPC:
+      CIDR: "0/24" #10.255.X.0/24 = 10.255.X.0-10.255.X.255
+    Public:
+      CIDR: "0/28" #10.255.X.0-15
+    Private:
+      CIDR: "16/26" #10.255.X.16-79
+    Public1:
+      CIDR: "80/28" #10.255.X.80-95
+    Private1:
+      CIDR: "96/26" #10.255.X.96-159
+    Public2:
+      CIDR: "160/28" #10.255.X.160-175
+    Private2:
+      CIDR: "176/26" #10.255.X.176-240
+Resources:
+  VPC:
+    Type: "AWS::EC2::VPC"
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, VPC, CIDR]
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public, Public1, Public2, Private, Private1, Private2"
+        - Key: "Name"
+          Value: !Ref VpcName
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Public, CIDR]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref PublicSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public"
+        - Key: "Name"
+          Value: "Public"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PrivateSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private, CIDR]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref PrivateSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Private"
+        - Key: "Name"
+          Value: "Private"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PublicSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Public1, CIDR]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref PublicSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public1"
+        - Key: "Name"
+          Value: "Public1"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Public2, CIDR]
+      AvailabilityZone: !Select
+        - 2
+        - !Ref PublicSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public2"
+        - Key: "Name"
+          Value: "Public2"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PrivateSubnet1:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private1, CIDR]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref PrivateSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Private1"
+        - Key: "Name"
+          Value: "Private1"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PrivateSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, Private2, CIDR]
+      AvailabilityZone: !Select
+        - 2
+        - !Ref PrivateSubnetZones
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Private2"
+        - Key: "Name"
+          Value: "Private2"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+    Properties:
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public, Public1, Public2"
+        - Key: "Name"
+          Value: "Public, Public1, Public2"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+      InternetGatewayId:
+        Ref: "InternetGateway"
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public"
+        - Key: "Name"
+          Value: "Public"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: "GatewayToInternet"
+    Properties:
+      RouteTableId:
+        Ref: "PublicRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId:
+        Ref: "InternetGateway"
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet"
+      RouteTableId:
+        Ref: "PublicRouteTable"
+  PublicSubnetRouteTableAssociation1:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet1"
+      RouteTableId:
+        Ref: "PublicRouteTable"
+  PublicSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet2"
+      RouteTableId:
+        Ref: "PublicRouteTable"
+  PublicNetworkAcl:
+    Type: "AWS::EC2::NetworkAcl"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Public"
+        - Key: "Name"
+          Value: "Public"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  InboundHTTPPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: false
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
+  OutboundPublicNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: true
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 0
+        To: 65535
+  PublicSubnetNetworkAclAssociation:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet"
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+  PublicSubnetNetworkAclAssociation1:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet1"
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+  PublicSubnetNetworkAclAssociation2:
+    Type: "AWS::EC2::SubnetNetworkAclAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PublicSubnet2"
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+  NATGateway:
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - "ElasticIP"
+          - "AllocationId"
+      SubnetId:
+         Ref: "PublicSubnet"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  ElasticIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: "vpc"
+  PrivateRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId:
+        Ref: "VPC"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Network"
+          Value: "Private"
+        - Key: "Name"
+          Value: "Private"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  PrivateRouteToInternet:
+    Type: "AWS::EC2::Route"
+    Properties:
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId:
+        Ref: "NATGateway"
+  PrivateSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  PrivateSubnetRouteTableAssociation1:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet1"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  PrivateSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: "PrivateSubnet2"
+      RouteTableId:
+        Ref: "PrivateRouteTable"
+  # Allow access to EC2 when connected to the Sage VPN
+  VpnSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for VPN
+      VpcId:
+        Ref: "VPC"
+      SecurityGroupIngress:
+        - CidrIp: !Ref VpnCidr
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow all VPN traffic"
+      # CF does not support removing all rules, workaround is to add a pointless rule
+      SecurityGroupEgress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  # Allow access to bastian hosts
+  BastianSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for bastians
+      VpcId:
+        Ref: "VPC"
+      SecurityGroupIngress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: 22
+          ToPort: 22
+          IpProtocol: tcp
+          Description: "Allow SSH connection"
+      SecurityGroupEgress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  QuarantineSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for quarantining hosts
+      VpcId:
+        Ref: "VPC"
+      SecurityGroupIngress:
+        - CidrIp: !Ref VpnCidr
+          FromPort: 22
+          ToPort: 22
+          IpProtocol: tcp
+          Description: "Allow SSH connection from VPN route"
+        - CidrIp: !Ref VpnCidr
+          FromPort: 3389
+          ToPort: 3389
+          IpProtocol: tcp
+          Description: "Allow RDP connection from VPN route"
+      SecurityGroupEgress:
+        - CidrIp: "127.0.0.1/32"
+          IpProtocol: "-1"
+      Tags:
+        - Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+Outputs:
+  VPCId:
+    Description: "VPCId of the newly created VPC"
+    Value:
+      Ref: "VPC"
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VPCId']]
+  VpcCidr:
+    Description: "VPC CIDR of the newly created VPC"
+    Value: !GetAtt
+      - VPC
+      - CidrBlock
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcCidr']]
+  PublicSubnet:
+    Description: "SubnetId of the public subnet"
+    Value: !Ref PublicSubnet
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet']]
+  PublicSubnet1:
+    Description: "SubnetId of the public subnet 1"
+    Value: !Ref PublicSubnet1
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet1']]
+  PublicRouteTable:
+    Description: "Route table Id for public subnets"
+    Value: !Ref PublicRouteTable
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicRouteTable']]
+  PublicSubnet2:
+    Description: "SubnetId of the public subnet 2"
+    Value: !Ref PublicSubnet2
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet2']]
+  PrivateSubnet:
+    Description: "SubnetId of the private subnet"
+    Value: !Ref PrivateSubnet
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet']]
+  PrivateSubnet1:
+    Description: "SubnetId of the private subnet 1"
+    Value: !Ref PrivateSubnet1
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet1']]
+  PrivateSubnet2:
+    Description: "SubnetId of the private subnet 2"
+    Value: !Ref PrivateSubnet2
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet2']]
+  PrivateRouteTable:
+    Description: "Route table Id for private subnets"
+    Value: !Ref PrivateRouteTable
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateRouteTable']]
+  VpcDefaultSecurityGroup:
+    Description: "VPC DefaultSecurityGroup Id"
+    Value: { "Fn::GetAtt" : ["VPC", "DefaultSecurityGroup"] }
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcDefaultSecurityGroup']]
+  VpnSecurityGroup:
+    Description: "VPN Security Group Id"
+    Value: !Ref VpnSecurityGroup
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnSecurityGroup']]
+  BastianSecurityGroup:
+    Description: "Bastian Security Group Id"
+    Value: !Ref BastianSecurityGroup
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'BastianSecurityGroup']]
+  QuarantineSecurityGroup:
+    Description: "Quarantine Security Group Id"
+    Value: !Ref QuarantineSecurityGroup
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'QuarantineSecurityGroup']]
+  VpnCidr:
+    Description: "CIDR of the VPN used for the VpnSecurityGroup SecurityIngress"
+    Value: !Ref VpnCidr
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]


### PR DESCRIPTION
Here's one option for creating VPC peers for projects that don't use up or overlap address space among peer VPCs. This just takes our regular VPC template and reduces its subnets by one order of CIDR input. I'm suggesting that we reserve the high ranges of our address space for small subnets like this, e.g. 10.255.1..255.0/24 can fit a lot of discrete subnets. Private ranges are /26 and public ranges are /28 based on the assumption that resources are more frequently private.

We would use it like this:
````
template_path: remote/vpc-mini.yaml
stack_name: newvpcnameforproject
dependencies:
  - prod/bootstrap.yaml
parameters:
  VpcSubnetPrefix: "10.255.20"
  VpcName: newvpcnameforproject
hooks:
  before_launch:
    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc-mini.yaml --create-dirs -o templates/remote/vpc-mini.yaml"
````