### PR TITLE
Pin pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-ast
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.19.0
+    rev: v1.24.2
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.26.1
+    rev: v0.33.2
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
   include:
     - stage: validate
       script:
-        - pre-commit autoupdate
         - pre-commit run --all-files
         - sam build --build-dir lambdas/build/rotate-credentials --base-dir lambdas/rotate-credentials --template lambdas/rotate-credentials/template.yaml
         - sam build --build-dir lambdas/build/cfn-explode-macro --base-dir lambdas/cfn-explode-macro --template lambdas/cfn-explode-macro/template.yaml


### PR DESCRIPTION
cfn-lint v0.34.0 is breaking build with the following warnings:

"W4002 As the resource "metadata" section contains reference to a "NoEcho"
parameter JcSystemsGroupId, CloudFormation will display the parameter
value in plaintext.."

This will  pin cfn-lint hook to v0.33.2 so we don't get those silly warnings.
We also pin the other pre-commit hooks to the curret latest version.