### PR TITLE
SSM parameters template

### DIFF
--- a/templates/ssm-parameters.j2
+++ b/templates/ssm-parameters.j2
@@ -1,0 +1,46 @@
+# This is a cloudformation jinjaized template to install parameters into the
+# SSM parameter store.  This is only for non-securestring parameters.
+# Cloudformation does not support adding securestring parameters into the SSM.
+#
+# Usage:
+#  Create a sceptre template `my-ssm-params.yaml`
+#
+#  template_path: remote/ssm-parameters.j2
+#  hooks:
+#    before_launch:
+#      - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ssm-parameters.j2 --create-dirs -o templates/remote/ssm-parameters.j2"
+#  stack_name: my-ssm-vars
+#  sceptre_user_data:
+#    Prefix: /my-ssm-vars/
+#    Parameters:
+#      - Name: param1
+#        Value: foo
+#      - Name: param2
+#        Value: foo
+
+Description: "Setup parameters in the SSM parameter store"
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  {% for parameter in sceptre_user_data.Parameters %}
+  {%- set name = parameter.Name -%}
+  {%- set value = parameter.Value -%}
+    {{ name }}:
+      Type: AWS::SSM::Parameter
+      Properties:
+        Name: {{ sceptre_user_data.Prefix }}{{ name }}
+        Value: {{ value }}
+        Type: 'String'
+  {% endfor %}
+Outputs:
+  Prefix:
+    Value: {{ sceptre_user_data.Prefix }}
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Prefix'
+  {% for parameter in sceptre_user_data.Parameters %}
+  {%- set name = parameter.Name -%}
+  {%- set value = parameter.Value -%}
+    {{ name }}:
+      Value: !GetAtt {{ name }}.Value
+      Export:
+        Name: !Sub '${AWS::Region}-${AWS::StackName}-{{ name }}'
+  {% endfor %}


### PR DESCRIPTION
Add a cloudformation template to install parameters to the
SSM parameter store.  This is a generic jinja template that can
be used to install multiple SSM parameters into any AWS account.
This is only for non-securestring parameters.  Cloudformation
does not support adding securestring parameters into the SSM.