### PR TITLE
AWSConfigRole is deprecated, replaced by AWS_ConfigRole

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -238,7 +238,7 @@ Resources:
           Principal:
             Service: [config.amazonaws.com]
           Action: ['sts:AssumeRole']
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSConfigRole']
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWS_ConfigRole']
       Policies:
       - PolicyName: root
         PolicyDocument:


### PR DESCRIPTION
Email from AWS telling us that AWSConfigRole is being replaced by
AWS_ConfigRole.  This updates to the new role name.

As part of our continued effort to provide AWS customers with fine grained and secure
permissions management solutions, AWS Config has published a new managed policy called
AWS_ConfigRole that is scheduled to replace and subsequently deprecate AWSConfigRole
on December 1, 2020. This new policy removes the "S3:GetObject" permission as AWS
Config does not need permissions to read S3 objects.

The AWSConfigRole  managed policy will continue working for all currently attached
users, groups, and roles. However, effective December 1, 2020, AWSConfigRole managed
policy cannot be attached to any new users, groups, or roles. No action is needed if
your account does not utilize the AWSConfigRole managed policy.

For more information about deprecating managed policies, please refer to this document [1].

If you have any questions regarding this deprecation plan, please contact AWS Support [2].

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-deprecated.html
[2] https://aws.amazon.com/support