### PR TITLE
[IT-1004] Setup transit gateway spokes

### DIFF
--- a/templates/transit-gateway-spoke.yaml
+++ b/templates/transit-gateway-spoke.yaml
@@ -8,6 +8,7 @@ Parameters:
   TransitGatewayEndpointCidr:
     Description: 'The transit gateway endpoint CIDR'
     Type: String
+    AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
   VpcId:
     Description: 'The VPC ID to attach'
     Type: String

--- a/templates/transit-gateway-spoke.yaml
+++ b/templates/transit-gateway-spoke.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Setup the AWS transit gateway spoke
+Parameters:
+  TransitGatewayId:
+    Description: 'The sage transit gateway id'
+    Type: String
+  TransitGatewayEndpointCidr:
+    Description: 'The transit gateway endpoint CIDR'
+    Type: String
+  VpcId:
+    Description: 'The VPC ID to attach'
+    Type: String
+  VpcRouteTableId:
+    Description: 'The VPC route table ID'
+    Type: String
+  SubnetIds:
+    Description: 'The list of VPC subnet IDs to atttach'
+    Type: List<String>
+Resources:
+  TransitGatewayAttachment:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds: !Ref SubnetIds
+      TransitGatewayId: !Ref TransitGatewayId
+      VpcId: !Ref VpcId
+      Tags:
+        - Key: Name
+          Value: !Ref 'AWS::StackName'
+  RouteTable:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: !Ref TransitGatewayEndpointCidr
+      RouteTableId: !Ref VpcRouteTableId
+      TransitGatewayId: !Ref TransitGatewayId
+Outputs:
+  TransitGatewayAttachment:
+    Description: The transit gateway attachment ID
+    Value: !Ref TransitGatewayAttachment
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-TransitGatewayAttachmentId'

--- a/templates/transit-gateway-spoke.yaml
+++ b/templates/transit-gateway-spoke.yaml
@@ -28,8 +28,9 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'
-  RouteTable:
+  VpcRouteTable:
     Type: AWS::EC2::Route
+    DependsOn: TransitGatewayAttachment
     Properties:
       DestinationCidrBlock: !Ref TransitGatewayEndpointCidr
       RouteTableId: !Ref VpcRouteTableId


### PR DESCRIPTION
Add a template to setup transit gateway on the spoke end.
This template depends on a shared with ID `TransitGatewayId`.

Will require the following workflow:
1. share transit VPC (in transit account) to spoke accounts
2. accept sharing invitation in spoke account
3. run transit-gateway-spoke.yaml template to setup the spoke
account.