### PR TITLE
[IT-1005] template to create friendly redirect URL

### DIFF
--- a/templates/s3-redirector.yaml
+++ b/templates/s3-redirector.yaml
@@ -1,0 +1,103 @@
+# This template sets up an S3 static website with a routing rule to redirect (307)
+# to another website, optionally replacing the key. Also sets up a Cloudfront
+# distribution to handle https.
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Provision a S3 static website redirector with Cloudfront
+Parameters:
+  SourceHostName:
+    Description: The source endpoint (to redirect from)
+    Type: String
+    AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: must be a valid DNS zone name.
+  SourceAcmCertificateArn:
+    Description: The Amazon Resource Name (ARN) of an AWS Certificate Manager (ACM) certificate.
+    Type: String
+    AllowedPattern: "arn:aws:acm:.*"
+    ConstraintDescription: must be a valid certificate ARN.
+  TargetHostName:
+    Type: String
+    Description: The target endpoint 
+    AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: must be a valid DNS zone name.
+  TargetKey:
+    Type: String
+    Description: Optional target key
+    Default: ""
+Conditions:
+  HasTargetKey: !Not [ !Equals ["", !Ref TargetKey ] ]
+Resources:
+  WebsiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: PublicRead
+      BucketName: !Ref SourceHostName
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
+      RoutingRules:
+        RedirectRule:
+          HostName: !Ref TargetHostName
+          HttpRedirectCode: '307'
+          Protocol: https
+          ReplaceKeyWith: !If [ !Ref HasTargetKey, !Ref TargetKey, !Ref 'AWS::NoValue' ]
+     DeletionPolicy: Retain
+     UpdateReplacePolicy: Retain
+
+  Cloudfront:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: Cloudfront Distribution pointing to S3 bucket
+        Aliases:
+          - !Ref SourceHostName
+        Enabled: true
+        Origins:
+          - DomainName: !Select [2, !Split ["/", !GetAtt WebsiteBucket.WebsiteURL]]
+            Id: S3Origin
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: http-only
+        HttpVersion: 'http2'
+        DefaultRootObject: index.html
+        DefaultCacheBehavior:
+          DefaultTTL: 3600
+          AllowedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          TargetOriginId: S3Origin
+          ForwardedValues:
+            QueryString: true
+            Cookies:
+              Forward: none
+          ViewerProtocolPolicy: redirect-to-https
+        PriceClass: PriceClass_100
+        ViewerCertificate:
+          AcmCertificateArn: !Ref SourceAcmCertificateArn
+          SslSupportMethod: sni-only
+Outputs:
+  CloudfrontId:
+    Value: !Ref Cloudfront
+    Description: ID of the Cloudfront distribution
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudfrontId'
+  CloudfrontEndpoint:
+    Value: !Join
+      - ''
+      - - 'https://'
+        - !GetAtt Cloudfront.DomainName
+    Description: URL for cloudfront
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudfrontEndpoint'
+  BucketWebsiteUrl:
+    Value: !GetAtt WebsiteBucket.WebsiteURL
+    Description: URL for redirector
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BucketWebsiteUrl'
+  WebsiteBucket:
+    Value: !Ref WebsiteBucket
+    Description: The bucket containing the website redirect
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-WebsiteBucket'

--- a/templates/s3-redirector.yaml
+++ b/templates/s3-redirector.yaml
@@ -84,6 +84,7 @@ Resources:
         PriceClass: PriceClass_100
         ViewerCertificate:
           AcmCertificateArn: !Ref SourceAcmCertificateArn
+          MinimumProtocolVersion: TLSv1.2_2019
           SslSupportMethod: sni-only
 
   DnsRecord:
@@ -93,10 +94,10 @@ Resources:
       HostedZoneId: !Ref SourceHostedZoneId
       Name: !Ref SourceHostName
       Type: CNAME
-      TTL: '3600'
+      TTL: 3600
       ResourceRecords:
       - !GetAtt Cloudfront.DomainName
-    
+
 Outputs:
   CloudfrontId:
     Value: !Ref Cloudfront

--- a/templates/s3-redirector.yaml
+++ b/templates/s3-redirector.yaml
@@ -2,8 +2,7 @@
 # to another website, optionally replacing the key. Also sets up a Cloudfront
 # distribution to handle https.
 AWSTemplateFormatVersion: 2010-09-09
-Description: >-
-  Provision a S3 static website redirector with Cloudfront
+Description: Provision a S3 static website redirector with Cloudfront
 Parameters:
   SourceHostName:
     Description: The source endpoint (to redirect from)
@@ -17,7 +16,7 @@ Parameters:
     ConstraintDescription: must be a valid certificate ARN.
   TargetHostName:
     Type: String
-    Description: The target endpoint 
+    Description: The target endpoint
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
     ConstraintDescription: must be a valid DNS zone name.
   TargetKey:
@@ -25,7 +24,7 @@ Parameters:
     Description: Optional target key
     Default: ""
 Conditions:
-  HasTargetKey: !Not [ !Equals ["", !Ref TargetKey ] ]
+  HasTargetKey: !Not [ !Equals [ "", !Ref TargetKey ] ]
 Resources:
   WebsiteBucket:
     Type: AWS::S3::Bucket
@@ -35,14 +34,15 @@ Resources:
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: error.html
-      RoutingRules:
-        RedirectRule:
-          HostName: !Ref TargetHostName
-          HttpRedirectCode: '307'
-          Protocol: https
-          ReplaceKeyWith: !If [ !Ref HasTargetKey, !Ref TargetKey, !Ref 'AWS::NoValue' ]
-     DeletionPolicy: Retain
-     UpdateReplacePolicy: Retain
+        RoutingRules:
+          -
+            RedirectRule:
+              HostName: !Ref TargetHostName
+              HttpRedirectCode: '307'
+              Protocol: https
+              ReplaceKeyWith: !If [ HasTargetKey, !Ref TargetKey, !Ref "AWS::NoValue" ]
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
 
   Cloudfront:
     Type: AWS::CloudFront::Distribution

--- a/templates/s3-redirector.yaml
+++ b/templates/s3-redirector.yaml
@@ -2,7 +2,7 @@
 # to another website, optionally replacing the key. Also sets up a Cloudfront
 # distribution to handle https.
 AWSTemplateFormatVersion: 2010-09-09
-Description: Provision a S3 static website redirector with Cloudfront
+Description: Provision a website at https://SourceHostName that redirects (307) to https://TargetHostName[/targetKey].
 Parameters:
   SourceHostName:
     Description: The source endpoint (to redirect from)
@@ -14,17 +14,25 @@ Parameters:
     Type: String
     AllowedPattern: "arn:aws:acm:.*"
     ConstraintDescription: must be a valid certificate ARN.
-  TargetHostName:
+  SourceHostedZoneId:
+    Description: The ID of the hosted zone where the source endpoint will be created. Needs to be in same account.
     Type: String
+    MaxLength: 32
+    AllowedPattern: "[A-Z0-9]*"
+    ConstraintDescription: Must be a valid hosted zone ID
+    Default: ""
+  TargetHostName:
     Description: The target endpoint
+    Type: String
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
     ConstraintDescription: must be a valid DNS zone name.
   TargetKey:
+    Description: Optional target key, this is used to replace the path in the original url (sourcehost/path becomes targethost/key if specified)
     Type: String
-    Description: Optional target key
     Default: ""
 Conditions:
   HasTargetKey: !Not [ !Equals [ "", !Ref TargetKey ] ]
+  HasHostedZoneId: !Not [ !Equals [ "", !Ref SourceHostedZoneId ] ]
 Resources:
   WebsiteBucket:
     Type: AWS::S3::Bucket
@@ -77,6 +85,18 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref SourceAcmCertificateArn
           SslSupportMethod: sni-only
+
+  DnsRecord:
+    Condition: HasHostedZoneId
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref SourceHostedZoneId
+      Name: !Ref SourceHostName
+      Type: CNAME
+      TTL: '3600'
+      ResourceRecords:
+      - !GetAtt Cloudfront.DomainName
+    
 Outputs:
   CloudfrontId:
     Value: !Ref Cloudfront


### PR DESCRIPTION
[IT-1005] This template creates an S3 website configured with a routing rule to redirect to another website, Cloudfront is setup to handle https. Also supports an optional key to replace the incoming one. First intended use is a friendly url to the self-service portal for VPN client.


[IT-1005]: https://sagebionetworks.jira.com/browse/IT-1005