### PR TITLE
[IT-1101] Add templates to setup AWS master member guardduty

### DIFF
--- a/templates/GuardDuty/guard-duty-extension.yaml
+++ b/templates/GuardDuty/guard-duty-extension.yaml
@@ -1,0 +1,65 @@
+# From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty
+AWSTemplateFormatVersion: '2010-09-09'
+
+Parameters:
+  resourcePrefix:
+    Type: String
+
+  detectorId:
+    Type: String
+
+  bucketName:
+    Type: String
+
+Resources:
+
+  TrustedIpSet:
+    Type: AWS::GuardDuty::IPSet
+    Properties:
+      Name: !Sub '${resourcePrefix}-guardduty-trusted-ips'
+      Activate: true
+      DetectorId: !Ref detectorId
+      Format: TXT
+      Location: !Sub 's3://${bucketName}/trusted_ips.txt'
+
+  NotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: AWS Org GuardDuty Notification
+      TopicName: !Sub '${resourcePrefix}-guardduty-notification'
+
+  NotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref NotificationTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowEventsPublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref NotificationTopic
+
+  FindingRule:
+    Type: AWS::Events::Rule
+    DependsOn: NotificationTopicPolicy
+    Properties:
+      Name: !Sub '${resourcePrefix}-guardduty-finding-rule'
+      EventPattern:
+        source:
+          - aws.guardduty
+        detail-type:
+          - GuardDuty Finding
+      Targets:
+        - Id: NotificationTopic
+          Arn: !Ref NotificationTopic
+      State: ENABLED
+
+Outputs:
+  NotificationTopic:
+    Value: !Ref NotificationTopic
+    Export:
+      Name: !Sub '${AWS::StackName}-notification-topic'

--- a/templates/GuardDuty/guard-duty.yaml
+++ b/templates/GuardDuty/guard-duty.yaml
@@ -13,6 +13,11 @@ Resources:
 
   GuardDutyBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
     OrganizationBinding: !Ref LogArchiveBinding
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -31,6 +36,11 @@ Resources:
 
   GuardDutyBucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
     OrganizationBinding: !Ref LogArchiveBinding
     Properties:
       Bucket: !Ref GuardDutyBucket
@@ -51,6 +61,11 @@ Resources:
   Detector:
     OrganizationBinding: !Ref AllBinding
     Type: AWS::GuardDuty::Detector
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
     Properties:
       Enable: true
       FindingPublishingFrequency: FIFTEEN_MINUTES
@@ -58,12 +73,21 @@ Resources:
   Master:
     OrganizationBinding: !Ref MemberBinding
     Type: AWS::GuardDuty::Master
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1012
     Properties:
       DetectorId: !Ref Detector
       MasterId: !Ref accountId
 
   Member:
     Type: AWS::GuardDuty::Member
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E1010]
     ForeachAccount:
       !Ref MemberBinding
     Properties:

--- a/templates/GuardDuty/guard-duty.yaml
+++ b/templates/GuardDuty/guard-duty.yaml
@@ -1,0 +1,80 @@
+# From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty
+AWSTemplateFormatVersion: '2010-09-09-OC'
+
+Parameters:
+  resourcePrefix:
+    Type: String
+
+  accountId:
+    Type: String
+    Description: The identifier from the account used to manage GuardDuty
+
+Resources:
+
+  GuardDutyBucket:
+    Type: AWS::S3::Bucket
+    OrganizationBinding: !Ref LogArchiveBinding
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub '${resourcePrefix}-guardduty-finding'
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  GuardDutyBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    OrganizationBinding: !Ref LogArchiveBinding
+    Properties:
+      Bucket: !Ref GuardDutyBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: GuardDutyWrite
+            Effect: Allow
+            Principal:
+              Service: guardduty.amazonaws.com
+            Action:
+              - s3:PutObject
+              - s3:GetBucketLocation
+            Resource:
+              - !Sub 'arn:aws:s3:::${GuardDutyBucket}/*'
+              - !GetAtt GuardDutyBucket.Arn
+
+  Detector:
+    OrganizationBinding: !Ref AllBinding
+    Type: AWS::GuardDuty::Detector
+    Properties:
+      Enable: true
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+
+  Master:
+    OrganizationBinding: !Ref MemberBinding
+    Type: AWS::GuardDuty::Master
+    Properties:
+      DetectorId: !Ref Detector
+      MasterId: !Ref accountId
+
+  Member:
+    Type: AWS::GuardDuty::Member
+    ForeachAccount:
+      !Ref MemberBinding
+    Properties:
+      DetectorId: !Ref Detector
+      Email: !GetAtt CurrentAccount.RootEmail
+      MemberId: !Ref CurrentAccount
+      Status: Invited
+      DisableEmailNotification: true
+
+Outputs:
+  DetectorId:
+    Value: !Ref Detector
+    Export:
+      Name: !Sub '${AWS::StackName}-detector-id'

--- a/templates/GuardDuty/trusted-ips-bucket.yaml
+++ b/templates/GuardDuty/trusted-ips-bucket.yaml
@@ -1,6 +1,11 @@
 # From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty
 AWSTemplateFormatVersion: '2010-09-09'
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W2001]
+
 Parameters:
   resourcePrefix:
     Type: String

--- a/templates/GuardDuty/trusted-ips-bucket.yaml
+++ b/templates/GuardDuty/trusted-ips-bucket.yaml
@@ -1,0 +1,48 @@
+# From https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty
+AWSTemplateFormatVersion: '2010-09-09'
+
+Parameters:
+  resourcePrefix:
+    Type: String
+
+  bucketName:
+    Type: String
+
+Resources:
+  TrustedIpsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Ref bucketName
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  TrustedIpsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref TrustedIpsBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: GuardDutyRead
+            Effect: Allow
+            Principal:
+              Service: guardduty.amazonaws.com
+            Action:
+              - s3:GetObject
+            Resource: !Sub '${TrustedIpsBucket.Arn}/trusted_ips.txt'
+
+Outputs:
+  BucketName:
+    Value: !Ref TrustedIpsBucket
+    Export:
+      Name: !Sub '${AWS::StackName}-name'


### PR DESCRIPTION
These templates will allow org-formation to deploy guardduty in a
master member configuration[1].  All templates are just copied
from the ofn reference project[2]

[1] https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_accounts.html
[2] https://github.com/org-formation/org-formation-reference/tree/master/src/templates/070-guard-duty