### PR TITLE
[T-1101] Add templates to setup AWS master member config

### DIFF
--- a/templates/Config/config.yaml
+++ b/templates/Config/config.yaml
@@ -1,6 +1,8 @@
 # From https://github.com/org-formation/org-formation-reference/blob/master/src/templates/080-aws-config-inventory/config.yml
 AWSTemplateFormatVersion: '2010-09-09'
 
+# This is an org-formation file, not a cloudformation file therefore some cfn-lint rules do not apply
+# rules reference: https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#rules-1
 Metadata:
   cfn-lint:
     config:
@@ -97,7 +99,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
-        - Sid: AssumeRole1
+        - Sid: ConfigServiceAssumeRole
           Effect: Allow
           Principal:
             Service: 'config.amazonaws.com'

--- a/templates/Config/config.yaml
+++ b/templates/Config/config.yaml
@@ -1,0 +1,118 @@
+# From https://github.com/org-formation/org-formation-reference/blob/master/src/templates/080-aws-config-inventory/config.yml
+AWSTemplateFormatVersion: '2010-09-09'
+
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W2001]
+
+Parameters:
+  resourcePrefix:
+    Type: String
+
+  bucketName:
+    Type: String
+    Description: 'Name of the central S3 bucket containing AWS Config audit findings'
+
+Resources:
+  ConfigAuditBucket:
+    OrganizationBinding: !Ref LogArchiveBinding
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: 'AWS::S3::Bucket'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E3001]
+    Properties:
+      BucketName: !Ref bucketName
+      AccessControl: BucketOwnerFullControl
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  ConfigAuditBucketPolicy:
+    OrganizationBinding: !Ref LogArchiveBinding
+    Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E1012, E3001]
+    Properties:
+      Bucket: !Ref ConfigAuditBucket
+      PolicyDocument: # Taken from https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html#granting-access-in-another-account
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AWSConfigBucketPermissionsCheck
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt ConfigAuditBucket.Arn
+          - Sid: AWSConfigBucketExistenceCheck
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:ListBucket
+            Resource: !GetAtt ConfigAuditBucket.Arn
+          - Sid: AWSConfigBucketDelivery
+            Effect: Allow
+            Principal:
+              Service:
+                - config.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub '${ConfigAuditBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                's3:x-amz-acl': 'bucket-owner-full-control'
+
+  ConfigurationRecorder:
+    Type: 'AWS::Config::ConfigurationRecorder'
+    Properties:
+      RecordingGroup:
+        AllSupported: true
+        IncludeGlobalResourceTypes: true
+      RoleARN: !GetAtt ConfigurationRecorderRole.Arn
+
+  DeliveryChannel:
+    Type: 'AWS::Config::DeliveryChannel'
+    Properties:
+      ConfigSnapshotDeliveryProperties:
+        DeliveryFrequency: One_Hour
+      S3BucketName: !Ref ConfigAuditBucket
+
+  ConfigurationRecorderRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: AssumeRole1
+          Effect: Allow
+          Principal:
+            Service: 'config.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: 's3-policy'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: 's3:PutObject'
+            Resource: !Sub '${ConfigAuditBucket.Arn}/*'
+            Condition:
+              StringLike:
+                's3:x-amz-acl': 'bucket-owner-full-control'
+          - Effect: Allow
+            Action: 's3:GetBucketAcl'
+            Resource: !GetAtt ConfigAuditBucket.Arn


### PR DESCRIPTION
Add templates to allow org-formation to deploy aws config in a
master member configuration[1].  This emplate is just copied
from the ofn reference project[2]

[1] https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-config.html
[2] https://github.com/org-formation/org-formation-reference/blob/master/src/templates/080-aws-config-inventory