### PR TITLE
IT-1187: Parameterize minPasswordLenght with default of 16

### DIFF
--- a/templates/ORG/password-policy.yaml
+++ b/templates/ORG/password-policy.yaml
@@ -1,10 +1,17 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
+Parameters:
+  MinPasswordLength:
+    Default: 16
+    Description: The minimum length of a password
+    Type: Number
+    MinValue: 16
+
 Resources:
   PasswordPolicy:
     Type: Community::IAM::PasswordPolicy
     Properties:
-      MinimumPasswordLength: 18
+      MinimumPasswordLength: !Ref MinPasswordLength
       RequireLowercaseCharacters: true
       RequireNumbers: true
       RequireSymbols: true


### PR DESCRIPTION
The new default of 18 does not work with the initial password setup in ssm. Set to 16 as default overridable in _parameters.yaml.
