### PR TITLE
Remove restrictions on IAM users in member accounts

### DIFF
--- a/templates/SCP/prevent-disable-guardduty.yaml
+++ b/templates/SCP/prevent-disable-guardduty.yaml
@@ -23,13 +23,11 @@ Resources:
                     "Effect": "Deny",
                     "Action": [
                         "guardduty:AcceptInvitation",
-                        "guardduty:ArchiveFindings",
                         "guardduty:CreateDetector",
                         "guardduty:CreateFilter",
                         "guardduty:CreateIPSet",
                         "guardduty:CreateMembers",
                         "guardduty:CreatePublishingDestination",
-                        "guardduty:CreateSampleFindings",
                         "guardduty:CreateThreatIntelSet",
                         "guardduty:DeclineInvitations",
                         "guardduty:DeleteDetector",


### PR DESCRIPTION
- [x] This change removes excessive restrictions on IAM activity on GuardDuty from within member accounts and securitycentral. The reason this is not concerning is because a member account should be able to generate sample findings to make sure events are propagating, and because a member account cannot actually archive findings before event forwarding to the aggregate acct
- [x] passes pre-commit