### PR TITLE
cloudwatch log group template

### DIFF
--- a/templates/Cloudtrail/cloudtrail-trail.yaml
+++ b/templates/Cloudtrail/cloudtrail-trail.yaml
@@ -4,6 +4,12 @@ AWSTemplateFormatVersion: '2010-09-09-OC'
 Parameters:
   bucketName:
     Type: String
+  CloudWatchLogsLogGroupArn:
+    Type: String
+    Default: ""
+  CloudWatchLogsRoleArn:
+    Type: String
+    Default: ""
 
 Resources:
   CloudTrailBucket:
@@ -69,5 +75,5 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsMultiRegionTrail: true
       EnableLogFileValidation: true
-      CloudWatchLogsLogGroupArn: ''
-      CloudWatchLogsRoleArn: ''
+      CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
+      CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn

--- a/templates/Cloudwatch/cloudwatch-log.yaml
+++ b/templates/Cloudwatch/cloudwatch-log.yaml
@@ -1,0 +1,62 @@
+Description: Setup cloudwatch logs
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  RetentionInDays:
+    Type: Number
+    Description: >
+      The number of days to retain the log events in the specified log group. Possible values are:
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
+    Default: 90
+    MinValue: 1
+    MaxValue: 3653
+Resources:
+  LogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub '/aws/cloudtrail/${AWS::StackName}.log'
+      RetentionInDays: !Ref RetentionInDays
+  LogPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AWSCloudTrailCreateLogStream
+            Effect: Allow
+            Action:
+              - 'logs:CreateLogStream'
+            Resource:
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:${AWS::AccountId}_CloudTrail_${AWS::Region}*'
+          - Sid: AWSCloudTrailPutLogEvents
+            Effect: Allow
+            Action:
+              - 'logs:PutLogEvents'
+            Resource:
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:${AWS::AccountId}_CloudTrail_${AWS::Region}*'
+  LogRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "cloudtrail.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - !Ref LogPolicy
+Outputs:
+  LogGroupArn:
+    Description: Log group ARN
+    Value: !GetAtt LogGroup.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LogGroupArn'
+  LogRoleArn:
+    Description: Log role ARN
+    Value: !GetAtt LogRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LogRoleArn'

--- a/templates/Cloudwatch/cloudwatch-log.yaml
+++ b/templates/Cloudwatch/cloudwatch-log.yaml
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   RetentionInDays:
     Type: Number
-    Description: >
+    Description: >-
       The number of days to retain the log events in the specified log group. Possible values are:
       1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
     Default: 90


### PR DESCRIPTION
Create a template to deploy a cloudwatch log group.  The output of the
log group will be passed into the cloudtrail template.  This is to
allow us to send cloudtrail logs to cloudwatch for easier viewing
and querying.