### PR TITLE
Cross account access

### DIFF
--- a/templates/IAM/cross-account-access.yaml
+++ b/templates/IAM/cross-account-access.yaml
@@ -28,10 +28,10 @@ Parameters:
             }
           ]
         }
-  Principals:
+  PrincipalArns:
     Type: CommaDelimitedList
     Description: >-
-      Give this list of accounts/users/roles access to resources
+      Give this list of accounts/users/roles ARNs access to AWS resources
       Example:
         ["arn:aws:iam::111111111111:root", "arn:aws:iam::111111111111:user/jsmith"]
 Conditions:
@@ -62,7 +62,7 @@ Resources:
         Statement:
           - Effect: "Allow"
             Principal:
-              AWS: !Ref Principals
+              AWS: !Ref PrincipalArns
             Action:
               - "sts:AssumeRole"
               - "sts:TagSession"

--- a/templates/IAM/cross-account-access.yaml
+++ b/templates/IAM/cross-account-access.yaml
@@ -1,0 +1,68 @@
+Description: Setup cross account IAM access.  Give user in another AWS account access to resources.
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
+  # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      A list of managed policies for the role. Required if PolicyDocument not provided.
+      Example:
+        ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "arn:aws:iam::1111111111:policy/MY-EXISTING-POLICY"]
+  PolicyDocument:
+    Type: String
+    Default: ""
+    Description: >-
+      A JSON policy document to define a custom policy for the role. Required if ManagedPolicyArns not provided.
+      Example:
+        {
+          "Version":"2012-10-17",
+          "Statement":[
+            {
+              "Sid":"PublicRead",
+              "Effect":"Allow",
+              "Principal": "*",
+              "Action":["s3:GetObject","s3:GetObjectVersion"],
+              "Resource":["arn:aws:s3:::EXAMPLE-BUCKET/*"]
+            }
+          ]
+        }
+  Principals:
+    Type: CommaDelimitedList
+    Description: >-
+      Give this list of accounts/users/roles access to resources
+      Example:
+        ["arn:aws:iam::111111111111:root", "arn:aws:iam::111111111111:user/jsmith"]
+Conditions:
+  HasManagedPolicyArns: !Not
+    - !Equals
+      - !Join ["", !Ref ManagedPolicyArns]
+      - ''
+  HasPolicyDocument: !Not [!Equals [!Ref PolicyDocument, ""]]
+Resources:
+  ServicePolicy:
+    Condition: HasPolicyDocument
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Ref PolicyDocument
+  ServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      # Concatinate managed policy and custom policy
+      ManagedPolicyArns: !Split
+        - ","
+        - !Join
+            - ","
+            - - !If [HasPolicyDocument, !Ref ServicePolicy, !Ref 'AWS::NoValue']
+              - !If [HasManagedPolicyArns, !Join [",", !Ref "ManagedPolicyArns"], !Ref 'AWS::NoValue']
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref Principals
+            Action:
+              - "sts:AssumeRole"
+              - "sts:TagSession"

--- a/templates/IAM/cross-account-access.yaml
+++ b/templates/IAM/cross-account-access.yaml
@@ -66,3 +66,8 @@ Resources:
             Action:
               - "sts:AssumeRole"
               - "sts:TagSession"
+Outputs:
+  ServiceRoleArn:
+    Value: !GetAtt ServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleArn'


### PR DESCRIPTION
Add a template to allow a user in another AWS account IAM access to
resources in the current account that this template is deployed to.