### PR TITLE
update SSO template to allow setting inline policy

### DIFF
--- a/templates/SSO/aws-sso.yaml
+++ b/templates/SSO/aws-sso.yaml
@@ -18,9 +18,17 @@ Parameters:
     Type: String
     Default: AdministratorAccess
 
+  # Must provide either a list of managedPolicies or an inlinePolicy.
+  # Can also provide both a list of managedPolicies and an inlinePolicy.
   managedPolicies:
     Type: CommaDelimitedList
-    Default: arn:aws:iam::aws:policy/AdministratorAccess
+    Default: ''
+    Description: 'A list of AWS managed policy ARNs for a SSO permission set'
+
+  inlinePolicy:
+    Type: String
+    Default: ''
+    Description: 'An AWS policy document for a SSO permission set'
 
   sessionDuration:
     Type: String
@@ -34,6 +42,11 @@ Conditions:
 
   includePermissionSet: !Equals [ '', !Ref permissionSetArn ]
   includeMaster: !Not [ !Equals [ '', !Ref masterAccountId ] ]
+  includeInlinePolicy: !Not [ !Equals [ '', !Ref inlinePolicy ] ]
+  includeManagedPolicies: !Not
+    - !Equals
+      - !Join ['', !Ref managedPolicies]
+      - ''
 
 Resources:
 
@@ -44,8 +57,9 @@ Resources:
       Name: !Ref permissionSetName
       Description: !Sub '${permissionSetName} access to AWS organization'
       InstanceArn: !Ref instanceArn
-      ManagedPolicies: !Ref managedPolicies
+      ManagedPolicies: !If [ includeManagedPolicies, !Ref managedPolicies, !Ref 'AWS::NoValue' ]
       SessionDuration: !Ref sessionDuration
+      InlinePolicy: !If [ includeInlinePolicy, !Ref inlinePolicy, !Ref 'AWS::NoValue' ]
 
   AssignmentMaster:
     Type: AWS::SSO::Assignment

--- a/templates/SSO/aws-sso.yaml
+++ b/templates/SSO/aws-sso.yaml
@@ -18,8 +18,6 @@ Parameters:
     Type: String
     Default: AdministratorAccess
 
-  # Must provide either a list of managedPolicies or an inlinePolicy.
-  # Can also provide both a list of managedPolicies and an inlinePolicy.
   managedPolicies:
     Type: CommaDelimitedList
     Default: ''


### PR DESCRIPTION
AWS SSO parmeter sets does not support customer managed policies[1]
therefore we need to update the template to allow us to pass in
a inline policy.  This will allow us to define roles with custom
policies.

[1] https://forums.aws.amazon.com/thread.jspa?threadID=282793