### PR TITLE
[IT-1205] template for VPC peering request

### DIFF
--- a/templates/VPC/vpc-peering-request.yaml
+++ b/templates/VPC/vpc-peering-request.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Setup to authorize the VPC Peering request from a specific account
+  https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/VPCPeering
+Parameters:
+  VpcPeeringRequesterAwsAccountId:
+    Type: String
+    NoEcho: true
+    Description: The AWS account running the VPN
+    AllowedPattern: '[0-9]*'
+    ConstraintDescription: Must be account number without dashes
+Resources:
+  AuthorizerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${VpcPeeringRequesterAwsAccountId}:root'
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: VPCAuthorizer
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ec2:AcceptVpcPeeringConnection'
+                Resource:
+                  - '*'
+Outputs:
+  AuthorizerRoleArn:
+    Description: Cross account authorizer role ARN
+    Value: !GetAtt AuthorizerRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AuthorizerRoleArn'


### PR DESCRIPTION
Add a template to create a VPC peering request role. We did this
same thing in sceptre with essentials.yaml[1], this is to decouple
the role from essentials and allows org-formation to deploy it
without all the stuff in essentials.

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/essentials.yaml#L92