### PR TITLE
[IT-1295] Fix S3 bucket policy

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -83,10 +83,6 @@ Parameters:
     Type: String
     Description: (Optional) Name of the created bucket.
     Default: ""
-  AccountOwnerId:
-    Type: String
-    Description: >-
-      The AWS account owner ID (i.e. aws s3api list-buckets --query Owner.ID --output text)
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
   AllowUserAccess: !Not [!Equals [!Join ['', !Ref GrantAccess], "[]"]]
@@ -192,7 +188,7 @@ Resources:
               StringNotLike:
                 aws:userid:
                   - arn:aws:iam::325565585839:root
-                  - !Ref AccountOwnerID
+                  - !Ref AWS::AccountId
               StringNotEquals:
                 s3:x-amz-acl: bucket-owner-full-control
           -


### PR DESCRIPTION
The AWS cononical user id is the same as the AWS account id[1]
It be easier for users if we don't need them to get the cononical user
id to create buckets.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/finding-canonical-user-id.html