### PR TITLE
clarifying how StringNotLike works

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -185,7 +185,7 @@ Resources:
             Action: s3:PutObject
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
             Condition:
-              StringNotLike:
+              ForAllValues:StringNotLike:
                 aws:userid:
                   - arn:aws:iam::325565585839:root
                   - !Ref AWS::AccountId


### PR DESCRIPTION
In this template it's not clear if the condition is that the userid is different from **either one** of the two or different from **both** of the two.  We want the latter, and adding the explicit qualifier, `ForAllValues` makes it clear.