### PR TITLE
IT-1295: Fix StringNotLike logic to change OR to AND

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -188,6 +188,7 @@ Resources:
               StringNotLike:
                 aws:userid:
                   - arn:aws:iam::325565585839:root
+                aws:userid:
                   - !Ref AWS::AccountId
               StringNotEquals:
                 s3:x-amz-acl: bucket-owner-full-control

--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -186,10 +186,8 @@ Resources:
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
             Condition:
               StringNotLike:
-                aws:userid:
-                  - arn:aws:iam::325565585839:root
-                aws:userid:
-                  - !Ref AWS::AccountId
+                aws:userid: arn:aws:iam::325565585839:root
+                aws:userid: !Ref AWS::AccountId
               StringNotEquals:
                 s3:x-amz-acl: bucket-owner-full-control
           -


### PR DESCRIPTION
Fix StringNotLike logic to change OR to AND

As explained in [the doc's,](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html) , the original template, which has the form:

```
             StringNotLike:
                aws:userid:
                  - foo
                  - bar
```
returns TRUE if userid is unlike `foo` OR unlike `bar`.  This means that the condition returns TRUE for `userid`=`foo`, when we actually want it to return FALSE.  It will only return FALSE for string like `foobar` which matches both strings (and which we never expect to occur). The fix is to change this to:

```
             StringNotLike:
                aws:userid: foo
                aws:userid: bar
```

which means userid unlike `foo` AND userid unlike `bar`.  This will return FALSE for `foo` and `bar` but TRUE for `baz`, which is what we want.
