### PR TITLE
[IT-1295] Fix S3 OwnershipControls policy

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -143,6 +143,9 @@ Resources:
             AllowedOrigins: ['*']
             AllowedMethods: [GET, POST, PUT, HEAD]
             MaxAge: 3000
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       LifecycleConfiguration:
         Rules:
         - Id: DataLifecycleRule


### PR DESCRIPTION
We had forgotten to add `OwnershipControls` setting to
SynapseEncryptedExternalBucket resource when adding that
parameter in PR #284