### PR TITLE
IT-1295

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -188,6 +188,7 @@ Resources:
               StringNotLike:
                 aws:userid:
                   - arn:aws:iam::325565585839:root
+                aws:userid:
                   - !Ref AWS::AccountId
               StringNotEquals:
                 s3:x-amz-acl: bucket-owner-full-control

--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -170,6 +170,7 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Sid: SynapseBucketAccess
+            # gives Synapse access to the bucket
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
@@ -178,6 +179,7 @@ Resources:
             Principal:
               AWS: "325565585839"
           - Sid: SynapseObjectAccess
+            # gives Synapse access to objects in the bucket (R/O or R/W, depending on AllowWrite)
             Action:
               - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
               - "s3:*MultipartUpload*"
@@ -186,6 +188,7 @@ Resources:
             Principal:
               AWS: "325565585839"
           - Sid: BucketAccess
+            # gives grantees access to the bucket
             Effect: Allow
             Principal:
               AWS: !Ref GrantAccess
@@ -194,6 +197,7 @@ Resources:
               - "s3:GetBucketLocation"
              Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
           - Sid: ReadObjectAccess
+            # give grantees read access to objects
             Effect: Allow
             Principal:
               AWS: !Ref GrantAccess
@@ -204,8 +208,9 @@ Resources:
               - "s3:ListMultipartUploadParts"
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
           - !If
-              - AllowWrite
+            - AllowWrite
             - Sid: InternalPutObjectAccess
+              # gives bucket-account grantees the ability to upload objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess
@@ -214,13 +219,13 @@ Resources:
                 - "s3:PutObjectAcl"
               Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
               Condition:
-                StringLike:
-                  "aws:PrincipalArn":
-                    - "arn:aws:iam::055273631518:*"
-                    - "arn:aws:sts::055273631518:assumed-role/*"
+                StringEquals:
+                  "aws:PrincipalAccount": "055273631518"
+            - !Ref AWS::NoValue
           - !If
-              - AllowWrite
+            - AllowWrite
             - Sid: ExternalPutObjectAccess
+              # gives cross-account grantees the ability to upload objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess
@@ -231,6 +236,7 @@ Resources:
               Condition:
                 StringEquals:
                   s3:x-amz-acl: bucket-owner-full-control
+            - !Ref AWS::NoValue
 
   # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
   # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro

--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -186,10 +186,8 @@ Resources:
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
             Condition:
               StringNotLike:
-                aws:userid:
-                  - arn:aws:iam::325565585839:root
-                aws:userid:
-                  - !Ref AWS::AccountId
+                aws:userid: arn:aws:iam::325565585839:root
+                aws:userid: !Ref AWS::AccountId
               StringNotEquals:
                 s3:x-amz-acl: bucket-owner-full-control
           -

--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -29,7 +29,7 @@ Parameters:
     Default: false
   BucketVersioning:
     Type: String
-    Description: Enabled to enable bucket versionsing, default is Suspended
+    Description: Enabled to enable bucket versioning, default is Suspended
     AllowedValues:
       - Enabled
       - Suspended
@@ -169,36 +169,68 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          -
-            Sid: "ReadAccess"
-            Effect: "Allow"
+          - Sid: SynapseBucketAccess
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Effect: Allow
+            Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
+            Principal:
+              AWS: "325565585839"
+          - Sid: SynapseObjectAccess
+            Action:
+              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
+              - "s3:*MultipartUpload*"
+            Effect: Allow
+            Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
+            Principal:
+              AWS: "325565585839"
+          - Sid: BucketAccess
+            Effect: Allow
             Principal:
               AWS: !Ref GrantAccess
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
-            Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
-          -
-            Sid: "RequireCanonicalIdOnObjectUpdates"
-            Effect: Deny
-            Principal: "*"
-            Action: s3:PutObject
-            Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
-            Condition:
-              StringNotLike:
-                aws:userid: arn:aws:iam::325565585839:root
-                aws:userid: !Ref AWS::AccountId
-              StringNotEquals:
-                s3:x-amz-acl: bucket-owner-full-control
-          -
-            Sid: "WriteAccess"
-            Effect: "Allow"
+             Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
+          - Sid: ReadObjectAccess
+            Effect: Allow
             Principal:
               AWS: !Ref GrantAccess
             Action:
-              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
-              - "s3:*MultipartUpload*"
+              - "s3:GetObject"
+              - "s3:GetObjectAcl"
+              - "s3:AbortMultipartUpload"
+              - "s3:ListMultipartUploadParts"
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
+          - !If
+              - AllowWrite
+            - Sid: InternalPutObjectAccess
+              Effect: Allow
+              Principal:
+                AWS: !Ref GrantAccess
+              Action:
+                - "s3:PutObject"
+                - "s3:PutObjectAcl"
+              Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
+              Condition:
+                StringLike:
+                  "aws:PrincipalArn":
+                    - "arn:aws:iam::055273631518:*"
+                    - "arn:aws:sts::055273631518:assumed-role/*"
+          - !If
+              - AllowWrite
+            - Sid: ExternalPutObjectAccess
+              Effect: Allow
+              Principal:
+                AWS: !Ref GrantAccess
+              Action:
+                - "s3:PutObject"
+                - "s3:PutObjectAcl"
+              Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
+              Condition:
+                StringEquals:
+                  s3:x-amz-acl: bucket-owner-full-control
 
   # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
   # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro


### PR DESCRIPTION
This PR modifies the S3 bucket template to meet the requirements listed in IT-1295, i.e.:
- Can upload from Synapse;
- Can upload from the S3 console, when logged in as the bucket owner;
- Cannot upload from a different account without adding the `bucket-owner-full-control` ACL;
- CAN upload from a different account with the `bucket-owner-full-control` ACL.  Bucket owner assumes ownership;
- A different account cannot change the ACL of an object in the bucket.

I created this policy interactively in S3, converted the JSON to YAML and mapped it back into the CFN template.  It passes the CloudFormation Linter but we'll have to check it against the UAT bucket to ensure correctness.

There are six statements in the policy:
SynapseBucketAccess - gives Synapse access to the bucket
SynapseObjectAccess - gives Synapse access to objects in the bucket (R/O or R/W)
BucketAccess - gives grantees access to the bucket
ReadObjectAccess - give grantees read access to objects
InternalPutObjectAccess - gives bucket account grantees the ability to upload objects
ExternalPutObjectAccess - gives cross-account grantees the ability to upload objects

Note that the template has a boolean 'AllowWrite'. The *PutObjectAccess statements are conditioned on this boolean.