### PR TITLE
IT-1208:  Allowing omission of Synapse as a grantee

### DIFF
--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -172,24 +172,18 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: SynapseBucketAccess
-            # gives Synapse access to the bucket
-            Action:
-              - "s3:ListBucket*"
-              - "s3:GetBucketLocation"
-            Effect: Allow
-            Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
-            Principal:
-              AWS: "325565585839"
           - Sid: SynapseObjectAccess
-            # gives Synapse access to objects in the bucket (R/O or R/W, depending on AllowWrite)
+            # If Synapse is a grantee, gives Synapse access to objects in the bucket (R/O or R/W, depending on AllowWrite)
+            Effect: Allow
+            Principal:
+              AWS: !Ref GrantAccess
             Action:
               - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
               - "s3:*MultipartUpload*"
-            Effect: Allow
+            Condition:
+              StringEquals:
+                "aws:PrincipalAccount": "325565585839" 
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
-            Principal:
-              AWS: "325565585839"
           - Sid: BucketAccess
             # gives grantees access to the bucket
             Effect: Allow

--- a/templates/s3-bucket-v2.j2
+++ b/templates/s3-bucket-v2.j2
@@ -182,7 +182,7 @@ Resources:
               - "s3:*MultipartUpload*"
             Condition:
               StringEquals:
-                "aws:PrincipalAccount": "325565585839" 
+                "aws:PrincipalAccount": "325565585839"
             Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
           - Sid: BucketAccess
             # gives grantees access to the bucket


### PR DESCRIPTION
This PR changes the policy statement in s3-bucket-v2.j2.  Previously the policy *always* gave Synapse access, but this change allows the stack to decide whether to give Synapse access, by including or omitting the principal in the list of grantees.  (This is how the policy originally worked.) The changes are:
- remove the SynapseBucketAccess statement. (Synapse can get access through the BucketAccess statement, along with other grantees.
- modify the SynapseObjectAccess statement so that it only applies if Synapse is in the list of grantees. (An added `Condition` ensures the statement only applies to the Synapse principal and not to other grantees.)
