### PR TITLE
Add missing subnet exports to vpc-20-private.yaml template

### DIFF
--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -285,6 +285,12 @@ Outputs:
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcCidr']]
+  PublicSubnet:
+    Description: "SubnetId of the public subnet"
+    Value: !Ref PrivateSubnet
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet']]
   PrivateSubnet:
     Description: "SubnetId of the private subnet"
     Value: !Ref PrivateSubnet
@@ -303,6 +309,18 @@ Outputs:
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet2']]
+  PrivateSubnet3:
+    Description: "SubnetId of the private subnet 3"
+    Value: !Ref PrivateSubnet3
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet3']]
+  PrivateSubnet4:
+    Description: "SubnetId of the private subnet 4"
+    Value: !Ref PrivateSubnet4
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PrivateSubnet4']]
   PrivateRouteTable:
     Description: "Route table Id for private subnets"
     Value: !Ref PrivateRouteTable

--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -287,7 +287,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpcCidr']]
   PublicSubnet:
     Description: "SubnetId of the public subnet"
-    Value: !Ref PrivateSubnet
+    Value: !Ref PublicSubnet
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'PublicSubnet']]


### PR DESCRIPTION
Several subnets were left off the exports from the templates/VPC/vpc-20-private.yaml template. Add these.