### PR TITLE
update to python 3.8 in AccountAlertTopics.yaml lambda

### DIFF
--- a/templates/AccountAlertTopics.yaml
+++ b/templates/AccountAlertTopics.yaml
@@ -170,7 +170,7 @@ Resources:
     Condition: cDeployLambda
     Properties:
       Description: Send SNS Messages to Slack
-      Runtime: python2.7
+      Runtime: python3.8
       Handler: index.lambda_handler
       Timeout: 80
       Code:


### PR DESCRIPTION
Linter was complaining with the following message..

W2531 EOL runtime (python2.7) specified. Runtime is EOL since
2021-07-15 and updating will be disabled at 2021-09-30.
Please consider updating to python3.8

templates/AccountAlertTopics.yaml:173:7