### PR TITLE
Validate SSO permissionSet string length

### DIFF
--- a/templates/SSO/aws-sso.yaml
+++ b/templates/SSO/aws-sso.yaml
@@ -17,6 +17,8 @@ Parameters:
   permissionSetName:
     Type: String
     Default: AdministratorAccess
+    MinLength: 1
+    MaxLength: 32
 
   managedPolicies:
     Type: CommaDelimitedList


### PR DESCRIPTION
AWS has a 32 character limit on the permissionSetName.  This error
was returned when attempting to set a name that's longer that
it allowed..

ERROR: Resource PermissionSet failed because Resource handler returned message:
"Model validation failed (#/Name: expected maxLength: 32, actual: 33)"