### PR TITLE
Add all ECR actions to the ones excluded from the deny policies

### DIFF
--- a/templates/SCP/deny-all-regions-outside-us-east-1.yaml
+++ b/templates/SCP/deny-all-regions-outside-us-east-1.yaml
@@ -37,6 +37,7 @@ Resources:
                         "ec2:DescribeRegions",
                         "ec2:DescribeTransitGateways",
                         "ec2:DescribeVpnGateways",
+                        "ecr:*",
                         "fms:*",
                         "globalaccelerator:*",
                         "health:*",

--- a/templates/SCP/deny-all-regions-outside-us.yaml
+++ b/templates/SCP/deny-all-regions-outside-us.yaml
@@ -37,6 +37,7 @@ Resources:
                         "ec2:DescribeRegions",
                         "ec2:DescribeTransitGateways",
                         "ec2:DescribeVpnGateways",
+                        "ecr:*",
                         "fms:*",
                         "globalaccelerator:*",
                         "health:*",


### PR DESCRIPTION
This is the simpler of two proposed solutions to not being able to pull from eu-west-1: just allow `ecr:*` i.e. don't include it in the deny for regions outside us-east-1 and regions outside the U.S.

https://sagebionetworks.jira.com/browse/IT-1369