### PR TITLE
Expose ARN for KMS key as output

### DIFF
--- a/templates/KMS/kms-key.yaml
+++ b/templates/KMS/kms-key.yaml
@@ -78,3 +78,7 @@ Outputs:
     Value: !Ref Alias
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-Alias'
+  KeyArn:
+    Value: !GetAtt Key.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KeyArn'


### PR DESCRIPTION
I want to include the KMS key in a policy, so I need the ARN as an output. Once this is merged, can a new version be minted? Thanks! 