### PR TITLE
Expose service role ID as an CFN output

### DIFF
--- a/templates/IAM/service-account.yaml
+++ b/templates/IAM/service-account.yaml
@@ -92,3 +92,7 @@ Outputs:
     Value: !GetAtt ServiceRole.Arn
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleArn'
+  ServiceRoleId:
+    Value: !GetAtt ServiceRole.RoleId
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleId'


### PR DESCRIPTION
I need to use the role ID in a bucket policy [downstream](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/600-access/_tasks.yaml#L63), and it would be easier to leverage a CFN output instead of querying AWS using `!rcmd`. 

Once this is merged, I'll need a new version to be minted. 