### PR TITLE
Add S3 VPC gateway endpoints to all VPC templates

### DIFF
--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -28,8 +28,8 @@ Parameters:
   IncludeS3GatewayEndpoint:
     Type: String
     Description: >
-      true (default) to deploy an S3 VPC gateway endpoint bucket, 
-      false to skip endpoint (e.g., one already being deployed)
+      true (default) to deploy an S3 VPC gateway endpoint,
+      false to skip endpoint (e.g., one has already been deployed)
     AllowedValues:
       - true
       - false

--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -25,6 +25,17 @@ Parameters:
     Default: "10.1.0.0/16"
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+  IncludeS3GatewayEndpoint:
+    Type: String
+    Description: >
+      true (default) to deploy an S3 VPC gateway endpoint bucket, 
+      false to skip endpoint (e.g., one already being deployed)
+    AllowedValues:
+      - true
+      - false
+    Default: true
+Conditions:
+  EnableS3GatewayEndpoint: !Equals [!Ref IncludeS3GatewayEndpoint, true]
 Mappings:
   SubnetConfig:
     VPC:
@@ -280,6 +291,7 @@ Resources:
   # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
   S3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint
+    Condition: EnableS3GatewayEndpoint
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -371,6 +383,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
   S3GatewayEndpointId:
     Description: S3 VPC Gateway endpoint ID
+    Condition: EnableS3GatewayEndpoint
     Value: !Ref S3GatewayEndpoint
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'

--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -277,6 +277,22 @@ Resources:
           FromPort: -1
           ToPort: -1
           IpProtocol: "-1"
+  # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
+  S3GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+            Principal: "*"
+      VpcId: !Ref VPC
+      RouteTableIds:
+        - !Ref PublicRouteTable
+        - !Ref PrivateRouteTable
+      ServiceName: "com.amazonaws.us-east-1.s3"
 Outputs:
   VPCId:
     Description: "VPCId of the newly created VPC"
@@ -353,3 +369,8 @@ Outputs:
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
+  S3GatewayEndpointId:
+    Description: S3 VPC Gateway endpoint ID
+    Value: !Ref S3GatewayEndpoint
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'

--- a/templates/VPC/vpc-mini.yaml
+++ b/templates/VPC/vpc-mini.yaml
@@ -28,8 +28,8 @@ Parameters:
   IncludeS3GatewayEndpoint:
     Type: String
     Description: >
-      true (default) to deploy an S3 VPC gateway endpoint bucket, 
-      false to skip endpoint (e.g., one already being deployed)
+      true (default) to deploy an S3 VPC gateway endpoint,
+      false to skip endpoint (e.g., one has already been deployed)
     AllowedValues:
       - true
       - false

--- a/templates/VPC/vpc-mini.yaml
+++ b/templates/VPC/vpc-mini.yaml
@@ -25,6 +25,17 @@ Parameters:
     Default: "10.1.0.0/16"
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+  IncludeS3GatewayEndpoint:
+    Type: String
+    Description: >
+      true (default) to deploy an S3 VPC gateway endpoint bucket, 
+      false to skip endpoint (e.g., one already being deployed)
+    AllowedValues:
+      - true
+      - false
+    Default: true
+Conditions:
+  EnableS3GatewayEndpoint: !Equals [!Ref IncludeS3GatewayEndpoint, true]
 Mappings:
   SubnetConfig:
     VPC:
@@ -357,6 +368,7 @@ Resources:
   # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
   S3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint
+    Condition: EnableS3GatewayEndpoint
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -466,6 +478,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
   S3GatewayEndpointId:
     Description: S3 VPC Gateway endpoint ID
+    Condition: EnableS3GatewayEndpoint
     Value: !Ref S3GatewayEndpoint
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'

--- a/templates/VPC/vpc-mini.yaml
+++ b/templates/VPC/vpc-mini.yaml
@@ -354,6 +354,22 @@ Resources:
       SecurityGroupEgress:
         - CidrIp: "127.0.0.1/32"
           IpProtocol: "-1"
+  # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
+  S3GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+            Principal: "*"
+      VpcId: !Ref VPC
+      RouteTableIds:
+        - !Ref PublicRouteTable
+        - !Ref PrivateRouteTable
+      ServiceName: "com.amazonaws.us-east-1.s3"
 Outputs:
   VPCId:
     Description: "VPCId of the newly created VPC"
@@ -448,3 +464,8 @@ Outputs:
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
+  S3GatewayEndpointId:
+    Description: S3 VPC Gateway endpoint ID
+    Value: !Ref S3GatewayEndpoint
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -42,6 +42,17 @@ Parameters:
     AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
     Default: 'it@sagebase.org'
+  IncludeS3GatewayEndpoint:
+    Type: String
+    Description: >
+      true (default) to deploy an S3 VPC gateway endpoint bucket, 
+      false to skip endpoint (e.g., one already being deployed)
+    AllowedValues:
+      - true
+      - false
+    Default: true
+Conditions:
+  EnableS3GatewayEndpoint: !Equals [!Ref IncludeS3GatewayEndpoint, true]
 Mappings:
   SubnetConfig:
     VPC:
@@ -535,6 +546,7 @@ Resources:
   # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
   S3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint
+    Condition: EnableS3GatewayEndpoint
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -644,6 +656,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
   S3GatewayEndpointId:
     Description: S3 VPC Gateway endpoint ID
+    Condition: EnableS3GatewayEndpoint
     Value: !Ref S3GatewayEndpoint
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -45,8 +45,8 @@ Parameters:
   IncludeS3GatewayEndpoint:
     Type: String
     Description: >
-      true (default) to deploy an S3 VPC gateway endpoint bucket, 
-      false to skip endpoint (e.g., one already being deployed)
+      true (default) to deploy an S3 VPC gateway endpoint,
+      false to skip endpoint (e.g., one has already been deployed)
     AllowedValues:
       - true
       - false

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -532,6 +532,22 @@ Resources:
           Value: !Ref Project
         - Key: "OwnerEmail"
           Value: !Ref OwnerEmail
+  # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
+  S3GatewayEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+            Principal: "*"
+      VpcId: !Ref VPC
+      RouteTableIds:
+        - !Ref PublicRouteTable
+        - !Ref PrivateRouteTable
+      ServiceName: "com.amazonaws.us-east-1.s3"
 Outputs:
   VPCId:
     Description: "VPCId of the newly created VPC"
@@ -626,3 +642,8 @@ Outputs:
     Export:
       Name:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnCidr']]
+  S3GatewayEndpointId:
+    Description: S3 VPC Gateway endpoint ID
+    Value: !Ref S3GatewayEndpoint
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-S3GatewayEndpointId'


### PR DESCRIPTION
I'm propagating the change I made in Sage-Bionetworks-Workflows/nextflow-infra#67 to all VPC templates in this repository. The rationale is that it's free to run a VPC gateway endpoint, and we use S3 a lot at Sage. Hence, this can act as a preventative measure to avoid needless NAT gateway and inter-AZ traffic, which is costly. 

The resource and output added to each VPC template was taken from [`templates/gateway-vpc-endpoint.yaml`](https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/gateway-vpc-endpoint.yaml). The only change that I made was adding the VPC endpoint to the public route table in addition to the private route table. This will likely have no practical change since most S3 traffic is expected to originate from private subnets, but it also can't hurt to make sure all S3 traffic from a given VPC is routed through the endpoint instead of NAT gateways. 

We've already implemented this change for [Sage-Bionetworks-Workflows/nextflow-infra](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra), so we don't need you to mint a new release once this is merged. 

depends on https://github.com/Sage-Bionetworks/iAtlas-infra/pull/28