### PR TITLE
fork PyPlate for pining

### DIFF
--- a/templates/PyPlate/README.md
+++ b/templates/PyPlate/README.md
@@ -1,0 +1,39 @@
+# PyPlate
+
+Run arbitrary python code in your CloudFormation templates
+
+## Basic Usage
+
+Place python code as a literal bock anywhere in your template, the literal block will be replaced with the contents of
+the `output` variable defined in your code. There are several variables available to your code:
+
+params: dict containing the contents of the templateParameterValues
+template: dict containing the entire template
+account_id: AWS account ID
+region: AWS Region
+
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Description: tests String macro functions
+Parameters:
+  Tags:
+    Default: "Env=Prod,Application=MyApp,BU=ModernisationTeam"
+    Type: "CommaDelimitedList"
+Resources:
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      Tags: |
+        #!PyPlate
+        output = []
+        for tag in params['Tags']:
+           key, value = tag.split('=')
+           output.append({"Key": key, "Value": value})
+Transform: [PyPlate]
+```
+
+## Author
+
+[Jay McConnell](https://github.com/jaymccon)
+Partner Solutions Architect
+Amazon Web Services

--- a/templates/PyPlate/python.yaml
+++ b/templates/PyPlate/python.yaml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  TransformExecutionRole:
+
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+            Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: ['logs:*']
+                Resource: 'arn:aws:logs:*:*:*'
+  TransformFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import traceback
+          import json
+
+
+          def obj_iterate(obj, params):
+              if isinstance(obj, dict):
+                  for k in obj:
+                      obj[k] = obj_iterate(obj[k], params)
+              elif isinstance(obj, list):
+                  for i, v in enumerate(obj):
+                      obj[i] = obj_iterate(v, params)
+              elif isinstance(obj, str):
+                  if obj.startswith("#!PyPlate"):
+                      params['output'] = None
+                      exec(obj, params)
+                      obj = params['output']
+              return obj
+
+
+          def handler(event, context):
+
+              print(json.dumps(event))
+
+              macro_response = {
+                  "requestId": event["requestId"],
+                  "status": "success"
+              }
+              try:
+                  params = {
+                      "params": event["templateParameterValues"],
+                      "template": event["fragment"],
+                      "account_id": event["accountId"],
+                      "region": event["region"]
+                  }
+                  response = event["fragment"]
+                  macro_response["fragment"] = obj_iterate(response, params)
+              except Exception as e:
+                  traceback.print_exc()
+                  macro_response["status"] = "failure"
+                  macro_response["errorMessage"] = str(e)
+              return macro_response
+
+      Handler: index.handler
+      Runtime: python3.6
+      Role: !GetAtt TransformExecutionRole.Arn
+  TransformFunctionPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !GetAtt TransformFunction.Arn
+      Principal: 'cloudformation.amazonaws.com'
+  Transform:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [W1020]
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: !Sub 'PyPlate'
+      Description: Processes inline python in templates
+      FunctionName: !GetAtt TransformFunction.Arn

--- a/templates/PyPlate/python_example.yaml
+++ b/templates/PyPlate/python_example.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: tests String macro functions
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks: [W2001, E3002]
+Parameters:
+  Tags:
+    Default: "Env=Prod,Application=MyApp,BU=ModernisationTeam"
+    Type: "CommaDelimitedList"
+Resources:
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      Tags: |
+        #!PyPlate
+        output = []
+        for tag in params['Tags']:
+           key, value = tag.split('=')
+           output.append({"Key": key, "Value": value})
+Transform: [PyPlate]


### PR DESCRIPTION
We use PyPlate in the service catalog and currently we are getting it
from the upstream master branch[1].  The problem with that dependency
is that it's not tagged upstream so we cannot pin to a specific version.
Adding it to our repo allows us to tag and pin to a specific version
which will make it less prone to error.

The code is taken from awslabs as-is.

[1] https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/services/CloudFormation/MacrosExamples/PyPlate

