### PR TITLE
Replace and update template to deploy windows EC2

### DIFF
--- a/templates/EC2/jc-ec2-win.j2
+++ b/templates/EC2/jc-ec2-win.j2
@@ -58,9 +58,9 @@ Parameters:
     Type: String
     Default: 'yes'
   AMIId:
-    Description: Deploy with the latest released AWS AMI
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: '/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base'
+    Description: The ID of the AMI to deploy
+    Type: 'AWS::EC2::Image::Id'
+    ConstraintDescription: Valid AMIs are at https://ami.sageit.org/
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number

--- a/templates/EC2/jc-ec2-win.j2
+++ b/templates/EC2/jc-ec2-win.j2
@@ -1,14 +1,19 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
+  Provision Windows EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
 Parameters:
+  JcUserId:
+    Description: 'ID used to associate EC2 to Jumpcloud user'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: 'AWS::EC2::KeyPair::KeyName'
     ConstraintDescription: must be the name of an existing EC2 KeyPair.
     Default: ""
   InstanceType:
-    Description: WebServer EC2 instance type
+    Description: EC2 instance type
     Type: String
     Default: t3.medium
   JcConnectKey:
@@ -40,21 +45,6 @@ Parameters:
     Description: 'Name of an existing VPC to run the instance in'
     Type: String
     Default: sandcastlevpc
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
   EncryptVolume:
     Type: String
     Description: true to encrypt root volume, false (default) for no encryption
@@ -68,8 +58,9 @@ Parameters:
     Type: String
     Default: 'yes'
   AMIId:
-    Description: ID of the AMI to deploy
-    Type: String
+    Description: Deploy with the latest released AWS AMI
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base'
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
@@ -114,13 +105,6 @@ Resources:
           FromPort: -1
           ToPort: -1
           IpProtocol: "-1"
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   {% endif %}
   Ec2Instance:
     Type: 'AWS::EC2::Instance'
@@ -134,8 +118,6 @@ Resources:
           SetupJumpcloud:
             - install_jc
             - config_jc
-          SetupVolume:
-            - tag_volume
         # Cfn-hup setting, it is to monitor the change of metadata.
         # When there is change in the contents of json file in the metadata section, cfn-hup will call cfn-init.
         cfn_hup_service:
@@ -151,7 +133,7 @@ Resources:
                  [cfn-auto-reloader-hook]
                  triggers=post.update
                  path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
-                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud,SetupVolume
+                 action=cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud
           services:
             windows:
               cfn-hup:
@@ -217,34 +199,13 @@ Resources:
                   - ' -JcSystemsGroupId '
                   - !Ref JcSystemsGroupId
                   - ' -OwnerEmail '
-                  - !Ref OwnerEmail
+                  - !Ref JcUserId
                   - ' > C:\scripts\associate-jc-system.log'
-        tag_volume:
-          files:
-             "c:\\scripts\\tag-instance-volume.ps1":
-              source: "https://raw.githubusercontent.com/Sage-Bionetworks/infra-utils/v1.0.2/aws/tag-instance-volume.ps1"
-              mode: "0664"
-          commands:
-            01_tag_instance_volume:
-              command: !Join
-                - ''
-                - - 'Powershell.exe Set-ExecutionPolicy Bypass -Scope Process -Force;'
-                  - 'Powershell.exe C:\scripts\tag-instance-volume.ps1 '
-                  - ' -AwsRegion '
-                  - !Ref AWS::Region
-                  - ' -StackName '
-                  - !Ref AWS::StackName
-                  - ' -Department '
-                  - !Ref Department
-                  - ' -Project '
-                  - !Ref Project
-                  - ' -OwnerEmail '
-                  - !Ref OwnerEmail
-                  - ' > C:\scripts\tag-instance-volume.log'
     Properties:
       ImageId: !Ref AMIId
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      PropagateTagsToVolumeOnCreation: true
       BlockDeviceMappings:
         -
           DeviceName: "/dev/sda1"
@@ -268,20 +229,12 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           <script>
-          cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud,SetupVolume
+          cfn-init.exe -v --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region} --configsets SetupCfn,SetupApps,SetupJumpcloud
           cfn-signal.exe -e %errorlevel% --stack ${AWS::StackId} --resource Ec2Instance --region ${AWS::Region}
           </script>
       Tags:
         - Key: "parkmycloud"
           Value: !Ref ParkMyCloudManaged
-        - Key: "Name"
-          Value: !Ref 'AWS::StackName'
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
     CreationPolicy:
       ResourceSignal:
         Count: 1
@@ -298,14 +251,6 @@ Resources:
       Tags:
         - Key: "parkmycloud"
           Value: !Ref ParkMyCloudManaged
-        - Key: "Name"
-          Value: !Ref 'AWS::StackName'
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 Outputs:
   Ec2InstanceId:
     Value: !Ref Ec2Instance
@@ -320,7 +265,3 @@ Outputs:
     Value: !GetAtt Ec2Instance.PublicIp
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePublicIp'
-  OwnerEmail:
-    Value: !Ref OwnerEmail
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'


### PR DESCRIPTION
This is to replace the template to provision windows instances.

* Use PropagateTagsToVolumeOnCreation[1] property to progpogate
  tags applied to the EC2 onto the attached stroage volume. We
  no longer need custom code to propogate tags.
* Remove tags as parameter to allow passing in tags from
  cloudformation
* Move template to EC2 folder
* Add JcUserId parameter to give Jumpcloud user access to instance

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-propagatetagstovolumeoncreation
