### PR TITLE
Enable transparent cross-account access

### DIFF
--- a/templates/IAM/transparent-cross-account-access.j2
+++ b/templates/IAM/transparent-cross-account-access.j2
@@ -1,0 +1,76 @@
+Description: >
+  Setup cross account IAM access.  Give user in another AWS account access to resources.
+  Ensures that the role session name is preserved when assuming the new role.
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  # Must provide either a list of ManagePolicyArns or a custom PolicyDocument.
+  # Can also provide both a list of ManagePolicyArns and a custom PolicyDocument.
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      A list of managed policies for the role. Required if PolicyDocument not provided.
+      Example:
+        ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "arn:aws:iam::1111111111:policy/MY-EXISTING-POLICY"]
+  PolicyDocument:
+    Type: String
+    Default: ""
+    Description: >-
+      A JSON policy document to define a custom policy for the role. Required if ManagedPolicyArns not provided.
+      Example:
+        {
+          "Version":"2012-10-17",
+          "Statement":[
+            {
+              "Sid":"PublicRead",
+              "Effect":"Allow",
+              "Principal": "*",
+              "Action":["s3:GetObject","s3:GetObjectVersion"],
+              "Resource":["arn:aws:s3:::EXAMPLE-BUCKET/*"]
+            }
+          ]
+        }
+Conditions:
+  HasManagedPolicyArns: !Not
+    - !Equals
+      - !Join ["", !Ref ManagedPolicyArns]
+      - ''
+  HasPolicyDocument: !Not [!Equals [!Ref PolicyDocument, ""]]
+Resources:
+  ServicePolicy:
+    Condition: HasPolicyDocument
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Ref PolicyDocument
+  ServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      # Concatinate managed policy and custom policy
+      ManagedPolicyArns: !Split
+        - ","
+        - !Join
+            - ","
+            - - !If [HasPolicyDocument, !Ref ServicePolicy, !Ref 'AWS::NoValue']
+              - !If [HasManagedPolicyArns, !Join [",", !Ref "ManagedPolicyArns"], !Ref 'AWS::NoValue']
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        {% for arn in sceptre_user_data.AssumedRoleArns %}
+        {% set arn_split    = arn.split('/') %}
+        {% set session_name = arn_split[-1]  %}
+          - Effect: "Allow"
+            Principal:
+              AWS: {{ arn }}
+            Condition:
+              StringLike:
+                sts:RoleSessionName: {{ session_name }}
+            Action:
+              - "sts:AssumeRole"
+              - "sts:TagSession"
+        {% endfor %}
+Outputs:
+  ServiceRoleArn:
+    Value: !GetAtt ServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ServiceRoleArn'


### PR DESCRIPTION
My goal with this new template is to create a role that select individuals can adopt while maintaining transparency on who is assuming the new role. In other words, I want to ensure that the role session name is preserved, which helps identify the individual when the listed `AssumedRoleArns` are assumed through JumpCloud/SSO. This transparency ensures that access to sensitive data is logged at the individual level. 

This way, if Sage employees need to be granted cross-account access by an external collaborator, we can provide a single IAM role ARN that they can list in a resource policy (_e.g._ S3 bucket). In turn, this ARN doesn't need to change anytime we internally update who should have access to those external AWS resources (_e.g._ as people are onboarded to the project). 

I'll need a new release once this PR is merged so I can use this template in `scicomp`. 

## Example

### Sceptre Config

```yaml
template_path: IAM/transparent-cross-account-access.j2
stack_name: transparent-cross-account-access-test

parameters:
  ManagedPolicyArns:
    - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"

sceptre_user_data:
  AssumedRoleArns:
    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
```

### Output IAM Role Trust Policy

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
            },
            "Action": [
                "sts:AssumeRole",
                "sts:TagSession"
            ],
            "Condition": {
                "StringLike": {
                    "sts:RoleSessionName": "bruno.grande@sagebase.org"
                }
            }
        },
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org"
            },
            "Action": [
                "sts:AssumeRole",
                "sts:TagSession"
            ],
            "Condition": {
                "StringLike": {
                    "sts:RoleSessionName": "thomas.yu@sagebase.org"
                }
            }
        }
    ]
}
```

### AWS CLI Config

```ini
[profile sandbox]
region = us-east-1
output = json
sso_region = us-east-1
sso_account_id = 563295687221
sso_start_url = https://d-906769aa66.awsapps.com/start
sso_role_name = Developer

[profile transparent-cross-account-access]
source_profile = sandbox
role_arn = arn:aws:iam::563295687221:role/transparent-cross-account-access-test-ServiceRole-1NURF9RNR9Y9K
role_session_name = bruno.grande@sagebase.org
```

### Caller Identity

```
❯ aws --profile transparent-cross-account-access-test sts get-caller-identity
{
    "UserId": "AROAYGJYKCI25SZETVOIY:bruno.grande@sagebase.org",
    "Account": "563295687221",
    "Arn": "arn:aws:sts::563295687221:assumed-role/transparent-cross-account-access-test-ServiceRole-1NURF9RNR9Y9K/bruno.grande@sagebase.org"
}
```