### PR TITLE
[IT-1234] AWS Security group for TGW

### DIFF
--- a/templates/VPC/vpc-20-private.yaml
+++ b/templates/VPC/vpc-20-private.yaml
@@ -282,6 +282,11 @@ Resources:
           ToPort: -1
           IpProtocol: "-1"
           Description: "Allow all VPN traffic"
+        - CidrIp: "10.50.0.0/16"    # AWS TGW Hub
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow AWS TGW Hub traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"

--- a/templates/VPC/vpc-mini.yaml
+++ b/templates/VPC/vpc-mini.yaml
@@ -321,6 +321,11 @@ Resources:
           ToPort: -1
           IpProtocol: "-1"
           Description: "Allow all VPN traffic"
+        - CidrIp: "10.50.0.0/16"    # AWS TGW Hub
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow AWS TGW Hub traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -469,6 +469,11 @@ Resources:
           ToPort: -1
           IpProtocol: "-1"
           Description: "Allow all VPN traffic"
+        - CidrIp: "10.50.0.0/16"    # AWS TGW Hub
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: "-1"
+          Description: "Allow AWS TGW Hub traffic"
       # CF does not support removing all rules, workaround is to add a pointless rule
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"


### PR DESCRIPTION
We use the transit gateway to route traffic between the hub
and spoke VPCs.  To allow access to resources in a spoke VPC we need
to give the hub VPC access to the resources.  This adds an SG ingress
to resources provisioned in our spoke VPCs which will allow VPN users
access to the resources in the spoke VPCs.

