### PR TITLE
[IT-1904] Enable cloudtrail encryption

### DIFF
--- a/templates/Cloudtrail/cloudtrail-trail.yaml
+++ b/templates/Cloudtrail/cloudtrail-trail.yaml
@@ -10,7 +10,11 @@ Parameters:
   CloudWatchLogsRoleArn:
     Type: String
     Default: ""
-
+  KmsKeyId:
+    Type: String
+    Default: ""
+Conditions:
+    HasKmsKeyId: !Not [!Equals ["", !Ref KmsKeyId]]
 Resources:
   CloudTrailBucket:
     OrganizationBinding: !Ref LogArchiveBinding
@@ -77,6 +81,7 @@ Resources:
       EnableLogFileValidation: true
       CloudWatchLogsLogGroupArn: !Ref CloudWatchLogsLogGroupArn
       CloudWatchLogsRoleArn: !Ref CloudWatchLogsRoleArn
+      KMSKeyId: !If [HasKmsKeyId, !Ref KmsKeyId, !Ref 'AWS::NoValue']
 
 Outputs:
   CloudTrailBucketName:


### PR DESCRIPTION
Add a parameter to the cloudtrail template to encrypt cloudtrail logs[1]
with a provided KMS key.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html#cfn-cloudtrail-trail-kmskeyid
