### PR TITLE
[IT-2052] Replace `jq` filter with api filter

### DIFF
--- a/templates/EC2/jc-ec2-linux.j2
+++ b/templates/EC2/jc-ec2-linux.j2
@@ -212,12 +212,13 @@ Resources:
               command: !Join
                 - ''
                 - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
-                  - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
-                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
-                  - !Ref JcServiceApiKey
-                  - "' | jq -r '.results | .[] | select(.email==\""
+                  - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET "
+                  - "'https://console.jumpcloud.com/api/systemusers?filter=email:$eq:"
                   - !Ref JcUserId
-                  - "\") | .id'); "
+                  - "' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  - !Ref JcServiceApiKey
+                  - "' | jq -r '.results | .[] | .id'); "
+                  - "echo Found ID $JC_USER_ID; "
                   - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
                   - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
                   - !Ref JcServiceApiKey


### PR DESCRIPTION
There was a recent failure while deploying the 'jharker-test' stack in
the 'sandbox-provisioner' project during the '02_associate_jc_systems'
command. The resulting virtual machine did not have the required
association and was not accessible using ssh keys from jumpcloud.

The underlying user ID could not be found because it does not appear in the
default list of system users, but can be found when searching based on
email address.
    
Replace the client-side `jq` filter with a server-side api filter.

