### PR TITLE
Update synapse S3 bucket policy

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -166,7 +166,6 @@ Resources:
               Action:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
-                - "s3:DeleteObject"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
               Condition:
                 StringEquals:
@@ -185,7 +184,7 @@ Resources:
             - E3001
     Properties:
       Target:
-        Bucket: [ !Ref Bucket ]
+        Bucket: !Ref Bucket
         Key: owner.txt
         ContentType: text
         ACL: authenticated-read

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -114,7 +114,7 @@ Resources:
             Principal:
               AWS: !Ref GrantAccess
             Action:
-              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
+              - !If [AllowWrite, "s3:*Object*"]
               - "s3:*MultipartUpload*"
             Condition:
               StringEquals:
@@ -143,13 +143,14 @@ Resources:
           - !If
             - AllowWrite
             - Sid: InternalPutObjectAccess
-              # gives bucket-account grantees the ability to upload objects
+              # gives bucket-account grantees the ability to upload and delete objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess
               Action:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
+                - "s3:DeleteObject"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
               Condition:
                 StringEquals:
@@ -158,13 +159,14 @@ Resources:
           - !If
             - AllowWrite
             - Sid: ExternalPutObjectAccess
-              # gives cross-account grantees the ability to upload objects
+              # gives cross-account grantees the ability to upload and delete objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess
               Action:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
+                - "s3:DeleteObject"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
               Condition:
                 StringEquals:

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -114,7 +114,7 @@ Resources:
             Principal:
               AWS: !Ref GrantAccess
             Action:
-              - !If [AllowWrite, "s3:*Object*"]
+              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
               - "s3:*MultipartUpload*"
             Condition:
               StringEquals:

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -159,7 +159,7 @@ Resources:
           - !If
             - AllowWrite
             - Sid: ExternalPutObjectAccess
-              # gives cross-account grantees the ability to upload and delete objects
+              # gives cross-account grantees the ability to upload objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess


### PR DESCRIPTION
According to the synapse custom storage location docs[1] the
read-write permissions should contain "s3:DeleteObject" permission.

Update the policy in our templates to add that missing permission.

[1] https://help.synapse.org/docs/Custom-Storage-Locations.2048327803.html#CustomStorageLocations-Read-WritePermissions

