### PR TITLE
Broaden KMS admin permissions

### DIFF
--- a/templates/KMS/kms-key.yaml
+++ b/templates/KMS/kms-key.yaml
@@ -19,7 +19,9 @@ Parameters:
     Description: Number of days before KMS delets the key
   AdminPrincipalArns:
     Type: CommaDelimitedList
-    Description: List of user/role/account arns that can administer the key
+    Description: >
+      List of user/role/account arns that can administer the key.
+      Should include "arn:aws:iam::${AWS::AccountId}:root".
   UserPrincipalArns:
     Type: CommaDelimitedList
     Description: List of user/role/account arn that can use the key
@@ -39,18 +41,7 @@ Resources:
             Principal:
               AWS: !Ref AdminPrincipalArns
             Action:
-              - "kms:Create*"
-              - "kms:Describe*"
-              - "kms:Enable*"
-              - "kms:List*"
-              - "kms:Put*"
-              - "kms:Update*"
-              - "kms:Revoke*"
-              - "kms:Disable*"
-              - "kms:Get*"
-              - "kms:Delete*"
-              - "kms:ScheduleKeyDeletion"
-              - "kms:CancelKeyDeletion"
+              - "kms:*"
             Resource: "*"
           -
             Sid: "Allow use of the key"

--- a/templates/KMS/kms-key.yaml
+++ b/templates/KMS/kms-key.yaml
@@ -21,7 +21,7 @@ Parameters:
     Type: CommaDelimitedList
     Description: >
       List of user/role/account arns that can administer the key.
-      Should include "arn:aws:iam::${AWS::AccountId}:root".
+      Should include "arn:aws:iam::<account-id>:root".
   UserPrincipalArns:
     Type: CommaDelimitedList
     Description: List of user/role/account arn that can use the key


### PR DESCRIPTION
I'm running into an [issue](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/runs/7645108962?check_suite_focus=true#step:11:145) when updating a stack that includes this KMS template as a nested stack. In CloudFormation, I found the following error. It seems like the `kms:UntagResource` is missing from [this list](https://github.com/Sage-Bionetworks/aws-infra/blob/9db3b9eb1757d9f834f841bb5b79c79a5de9ac18/templates/KMS/kms-key.yaml#L42-L53). Based on these [AWS docs](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam), I wonder if we can just grant `kms:*` to the key admins. 

```
Resource handler returned message: "Access denied for operation 'UntagResource'." 
```