### PR TITLE
[IT-2075] Allow bucket collaboration

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -90,7 +90,8 @@ Resources:
             MaxAge: 3000
       OwnershipControls:
         Rules:
-          - ObjectOwnership: BucketOwnerPreferred
+          - ObjectOwnership: BucketOwnerEnforced
+
       LifecycleConfiguration:
         Rules:
         - Id: DataLifecycleRule
@@ -143,7 +144,7 @@ Resources:
           - !If
             - AllowWrite
             - Sid: InternalPutObjectAccess
-              # gives scicomp bucket-account grantees the ability to upload and delete objects
+              # gives bucket-account grantees the ability to upload and delete objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess
@@ -153,27 +154,6 @@ Resources:
                 - "s3:DeleteObject"
                 - "s3:*MultipartUpload*"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
-              Condition:
-                StringEquals:
-                  "aws:PrincipalAccount": "055273631518"
-            - !Ref AWS::NoValue
-          - !If
-            - AllowWrite
-            - Sid: ExternalPutObjectAccess
-              # gives cross-account grantees the ability to upload objects
-              Effect: Allow
-              Principal:
-                AWS: !Ref GrantAccess
-              Action:
-                - "s3:PutObject"
-                - "s3:PutObjectAcl"
-                # "s3:DeleteObject" returns Conditions do not apply to combination of actions and resources in statement
-                # "s3:*MultipartUpload*" returns  Policy has invalid action
-                # "s3:DeleteObject" returns Conditions do not apply to combination of actions and resources in statement
-              Resource: [ !Sub "${Bucket.Arn}/*" ]
-              Condition:
-                StringEquals:
-                  s3:x-amz-acl: bucket-owner-full-control
             - !Ref AWS::NoValue
 
   # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -128,6 +128,7 @@ Resources:
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
+              - "s3:ListBucketMultipartUploads"
             Resource: [ !GetAtt Bucket.Arn ]
           - Sid: ReadObjectAccess
             # give grantees read access to objects
@@ -137,7 +138,6 @@ Resources:
             Action:
               - "s3:GetObject"
               - "s3:GetObjectAcl"
-              - "s3:AbortMultipartUpload"
               - "s3:ListMultipartUploadParts"
             Resource: [ !Sub "${Bucket.Arn}/*" ]
           - !If
@@ -151,6 +151,7 @@ Resources:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
                 - "s3:DeleteObject"
+                - "s3:*MultipartUpload*"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
               Condition:
                 StringEquals:
@@ -166,6 +167,9 @@ Resources:
               Action:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
+                # "s3:DeleteObject" returns Conditions do not apply to combination of actions and resources in statement
+                # "s3:*MultipartUpload*" returns  Policy has invalid action
+                # "s3:DeleteObject" returns Conditions do not apply to combination of actions and resources in statement
               Resource: [ !Sub "${Bucket.Arn}/*" ]
               Condition:
                 StringEquals:

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -143,7 +143,7 @@ Resources:
           - !If
             - AllowWrite
             - Sid: InternalPutObjectAccess
-              # gives bucket-account grantees the ability to upload and delete objects
+              # gives scicomp bucket-account grantees the ability to upload and delete objects
               Effect: Allow
               Principal:
                 AWS: !Ref GrantAccess

--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -129,7 +129,6 @@ Resources:
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
-              - "s3:ListBucketMultipartUploads"
             Resource: [ !GetAtt Bucket.Arn ]
           - Sid: ReadObjectAccess
             # give grantees read access to objects
@@ -143,7 +142,7 @@ Resources:
             Resource: [ !Sub "${Bucket.Arn}/*" ]
           - !If
             - AllowWrite
-            - Sid: InternalPutObjectAccess
+            - Sid: PutObjectAccess
               # gives bucket-account grantees the ability to upload and delete objects
               Effect: Allow
               Principal:


### PR DESCRIPTION
Occasionally we want to allow our external collaborators
to use the AWS CLI to upload files to buckets that we provision.
The bucket template to create an external synapse bucket does
not support that use case currently.  We need to update the
permissions to allow for that use case.

The fix is to change from BucketOwnerPreferred to BucketOwnerEnfored[1]
to disable ACLs and set the bucket owner to autmatically have full control over
every object in the bucket.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html