### PR TITLE
[IT-2075] remove bucket ACL setting

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -170,7 +170,6 @@ Resources:
         Bucket: !Ref Bucket
         Key: owner.txt
         ContentType: text
-        ACL: authenticated-read
       Body: >-
         {% for SynapseID in sceptre_user_data.SynapseIDs %}
           {{ SynapseID }}


### PR DESCRIPTION
This is a fix to PR #351 (setting `ObjectOwnership: BucketOwnerEnforced`)
When we do that we also need to remove the ACL setting from the S3Object
macro otherwise we'll get the following error..

```
[ERROR] ClientError: An error occurred (AccessControlListNotSupported) when calling
        the PutObject operation: The bucket does not allow ACLs
Traceback (most recent call last):
  File "/var/task/resource.py", line 72, in handler
    s3_client.put_object(**target)
  File "/var/runtime/botocore/client.py", line 391, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 719, in _make_api_call
    raise error_class(parsed_response, operation_name)
[ERROR] ClientError: An error occurred (AccessControlListNotSupported) when calling the
PutObject operation: The bucket does not allow ACLs Traceback (most recent call last):
File "/var/task/resource.py", line 72, in handler     s3_client.put_object(**target)
File "/var/runtime/botocore/client.py", line 391, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/runtime/botocore/client.py", line 719, in _make_api_call
raise error_class(parsed_response, operation_name)
```

