### PR TITLE
restoring inactive code since it's used in some SciComp stack

### DIFF
--- a/templates/tags/SageFinancialProgramCodesOther.json
+++ b/templates/tags/SageFinancialProgramCodesOther.json
@@ -8,6 +8,7 @@
   "ANTI PD1 CH-BMS / 507200",
   "AoU Governance-ELSI / 122901",
   "At Home-Mass Gen Hosp / 120000",
+  "BMGF-Ki / 30144",
   "BMGF COVID / 314700",
   "BMGF Synapse Data Hosting Services / 314400",
   "Bridge2AI Standards Core / 122600",


### PR DESCRIPTION
Restoring inactive code since it's used in some SciComp stack:

We got this error:
https://app.travis-ci.com/github/Sage-Bionetworks/scicomp-provisioner/jobs/580126789#L7435

> - config/prod/gates-ki-001.yaml: "BMGF-Ki / 30144" is not a valid CostCenter

The fix then is to restore the program code.  Can't remove it until all stacks that reference it have been updated.
