### PR TITLE
IT-2000: Make bastian sg option with default on

### DIFF
--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -503,7 +503,7 @@ Resources:
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
-    Condition: EnableBastionSecurityGroup
+    Condition: EnableBastianSecurityGroup
     Properties:
       GroupDescription: Security Group for bastians
       VpcId:

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -51,8 +51,18 @@ Parameters:
       - true
       - false
     Default: true
+  IncludeBastianSecurityGroup:
+    Type: String
+    Description: >
+      true (default) to deploy a bastian security group
+      false to skip the bastian security group
+    AllowedValues:
+      - true
+      - false
+    Default: true
 Conditions:
   EnableS3GatewayEndpoint: !Equals [!Ref IncludeS3GatewayEndpoint, true]
+  EnableBastianSecurityGroup: !Equals [!Ref IncludeBastianSecurityGroup, true]
 Mappings:
   SubnetConfig:
     VPC:
@@ -493,6 +503,7 @@ Resources:
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
+    Condition: EnableBastionSecurityGroup
     Properties:
       GroupDescription: Security Group for bastians
       VpcId:
@@ -643,6 +654,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnSecurityGroup']]
   BastianSecurityGroup:
     Description: "Bastian Security Group Id"
+    Condition: EnableBastianSecurityGroup
     Value: !Ref BastianSecurityGroup
     Export:
       Name:


### PR DESCRIPTION
The security group is getting flagged by SecurityHub EC2.19. The proposal is to make it optional for VPCs where it's not needed (default is to have it for backward compatibility).
