### PR TITLE
Update s3 policy to allow removing delete markers

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -150,7 +150,7 @@ Resources:
               Action:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
-                - "s3:DeleteObject"
+                - "s3:DeleteObject*"
                 - "s3:*MultipartUpload*"
               Resource: [ !Sub "${Bucket.Arn}/*" ]
             - !Ref AWS::NoValue


### PR DESCRIPTION
Delete markers can get created on failed file uploads which can block users from re-uploading the same file. The user must be able to remove the delete marker before re-uploading the file. This will allow s3:DeleteObjectVersion[1] permission which will  users to remove delete markers.

[1] https://aws.amazon.com/premiumsupport/knowledge-center/s3-undelete-configuration

