### PR TITLE
[IT-2268] Add support for CustomerManagedPolicyReference

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,4 +1,6 @@
 ignore_checks:
+  - E1001
+  - E2531
   - E3001
 ignore_templates:
   - templates/tags/*.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-ast
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.28.0
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.54.4
+    rev: v0.68.0
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.3.1
     hooks:
     -   id: remove-tabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.6
+python: 3.9
 cache: pip
 env:
   global:

--- a/templates/IAM/managed-policy.yaml
+++ b/templates/IAM/managed-policy.yaml
@@ -18,11 +18,17 @@ Parameters:
             }
           ]
         }
+  PolicyName:
+    Type: String
+    Default: ''
+Conditions:
+  includeName: !Not [ !Equals [ '', !Ref PolicyName ] ]
 Resources:
   ManagedPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
       PolicyDocument: !Ref PolicyDocument
+      ManagedPolicyName: !If [ includeName, !Ref PolicyName, !Ref 'AWS::NoValue' ]
 Outputs:
   ManagedPolicyArn:
     Value: !Ref ManagedPolicy

--- a/templates/SSO/aws-sso.njk
+++ b/templates/SSO/aws-sso.njk
@@ -25,11 +25,6 @@ Parameters:
     Default: ''
     Description: 'A list of AWS managed policy ARNs for a SSO permission set'
 
-  customerManagedPolicyName:
-    Type: String
-    Default: ''
-    Description: 'The name of an optional customer managed policy for a SSO permission set'
-
   inlinePolicy:
     Type: String
     Default: ''
@@ -48,7 +43,6 @@ Conditions:
   includePermissionSet: !Equals [ '', !Ref permissionSetArn ]
   includeMaster: !Not [ !Equals [ '', !Ref masterAccountId ] ]
   includeInlinePolicy: !Not [ !Equals [ '', !Ref inlinePolicy ] ]
-  includeCustomerManagedPolicy: !Not [ !Equals [ '', !Ref customerManagedPolicyName ] ]
   includeManagedPolicies: !Not
     - !Equals
       - !Join ['', !Ref managedPolicies]
@@ -64,13 +58,13 @@ Resources:
       Description: !Sub '${permissionSetName} access to AWS organization'
       InstanceArn: !Ref instanceArn
       ManagedPolicies: !If [ includeManagedPolicies, !Ref managedPolicies, !Ref 'AWS::NoValue' ]
+      {% if ( customerManagedPolicies | default(false) ) %}
       CustomerManagedPolicyReferences:
-        !If
-          - includeCustomerManagedPolicy
-          - # If we are setting a value, we are also embedding it as a single item in a list
-            -
-              Name: !Ref customerManagedPolicyName
-          - !Ref 'AWS::NoValue'
+        {% for policy in customerManagedPolicies %}
+        - Name: {{ policy['Name'] }}
+          Path: {{ policy['Path'] | default('/') }}
+        {% endfor %}
+      {% endif %}
       SessionDuration: !Ref sessionDuration
       InlinePolicy: !If [ includeInlinePolicy, !Ref inlinePolicy, !Ref 'AWS::NoValue' ]
 

--- a/templates/SSO/aws-sso.yaml
+++ b/templates/SSO/aws-sso.yaml
@@ -25,6 +25,11 @@ Parameters:
     Default: ''
     Description: 'A list of AWS managed policy ARNs for a SSO permission set'
 
+  customerManagedPolicyName:
+    Type: String
+    Default: ''
+    Description: 'The name of an optional customer managed policy for a SSO permission set'
+
   inlinePolicy:
     Type: String
     Default: ''
@@ -43,6 +48,7 @@ Conditions:
   includePermissionSet: !Equals [ '', !Ref permissionSetArn ]
   includeMaster: !Not [ !Equals [ '', !Ref masterAccountId ] ]
   includeInlinePolicy: !Not [ !Equals [ '', !Ref inlinePolicy ] ]
+  includeCustomerManagedPolicy: !Not [ !Equals [ '', !Ref customerManagedPolicyName ] ]
   includeManagedPolicies: !Not
     - !Equals
       - !Join ['', !Ref managedPolicies]
@@ -58,6 +64,13 @@ Resources:
       Description: !Sub '${permissionSetName} access to AWS organization'
       InstanceArn: !Ref instanceArn
       ManagedPolicies: !If [ includeManagedPolicies, !Ref managedPolicies, !Ref 'AWS::NoValue' ]
+      CustomerManagedPolicyReferences:
+        !If
+          - includeCustomerManagedPolicy
+          - # If we are setting a value, we are also embedding it as a single item in a list
+            -
+              Name: !Ref customerManagedPolicyName
+          - !Ref 'AWS::NoValue'
       SessionDuration: !Ref sessionDuration
       InlinePolicy: !If [ includeInlinePolicy, !Ref inlinePolicy, !Ref 'AWS::NoValue' ]
 


### PR DESCRIPTION
In order to use a custom managed policy for granting access to the cost explorer, we need to add support for at least one customer-managed policy to the managed-policy template. Adding support for multiple customer-managed policies in a single permission set will be more difficult due to the data structure of the parameter.

Updates to cfn-lint are required to avoid an E3002, and the updates also introduced new E2531 and E1001 occurrences - the former is a deprecation error for python 3.6, and the latter is related to org-formation syntax.