### PR TITLE
[IT-2221] Add flag for bastian access to vpc-mini

### DIFF
--- a/templates/VPC/vpc-mini.yaml
+++ b/templates/VPC/vpc-mini.yaml
@@ -34,8 +34,18 @@ Parameters:
       - true
       - false
     Default: true
+  IncludeBastianSecurityGroup:
+    Type: String
+    Description: >
+      true (default) to deploy a bastian security group
+      false to skip the bastian security group
+    AllowedValues:
+      - true
+      - false
+    Default: true
 Conditions:
   EnableS3GatewayEndpoint: !Equals [!Ref IncludeS3GatewayEndpoint, true]
+  EnableBastianSecurityGroup: !Equals [!Ref IncludeBastianSecurityGroup, true]
 Mappings:
   SubnetConfig:
     VPC:
@@ -330,6 +340,7 @@ Resources:
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
+    Condition: EnableBastianSecurityGroup
     Properties:
       GroupDescription: Security Group for bastians
       VpcId:
@@ -460,6 +471,7 @@ Outputs:
         !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VpnSecurityGroup']]
   BastianSecurityGroup:
     Description: "Bastian Security Group Id"
+    Condition: EnableBastianSecurityGroup
     Value: !Ref BastianSecurityGroup
     Export:
       Name:


### PR DESCRIPTION
Copy the IncludeBastianSecurityGroup parameter from the vpc template to the vpc-mini template so that we can disable access to `scheduledjobsvpc` in scipool prod.