### PR TITLE
Remove BMGFKi cost center

### DIFF
--- a/templates/tags/SageFinancialProgramCodesOther.json
+++ b/templates/tags/SageFinancialProgramCodesOther.json
@@ -11,7 +11,6 @@
   "At Home-Mass Gen Hosp / 120000",
   "BMGF COVID / 314700",
   "BMGF Synapse Data Hosting Services / 314400",
-  "BMGF-Ki / 30144",
   "Bridge2AI Standards Core / 122600",
   "Bridge2AI Teaming Core / 122700",
   "Bridge2AI Tool Optimization / 122800",


### PR DESCRIPTION
The BMGFKi cost center code has been removed and is no longer a valid cost center code.

