### PR TITLE
Update deprecated AWS config role

### DIFF
--- a/templates/Config/config.yaml
+++ b/templates/Config/config.yaml
@@ -95,7 +95,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       ManagedPolicyArns:
-      - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+      - 'arn:aws:iam::aws:policy/service-role/AWS_ConfigRole'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
The AWS built in `AWSConfigRole` has been deprecated[1] and replaced by `AWS_ConfigRole`.  

[1] https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/
