### PR TITLE
[IT-2431] Require HTTPS for guard duty trusted IPs

### DIFF
--- a/templates/GuardDuty/trusted-ips-bucket.yaml
+++ b/templates/GuardDuty/trusted-ips-bucket.yaml
@@ -45,6 +45,18 @@ Resources:
             Action:
               - s3:GetObject
             Resource: !Sub '${TrustedIpsBucket.Arn}/trusted_ips.txt'
+          # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule
+          - Sid: RequireSSL
+            Effect: Deny
+            Action:
+              - 's3:*'
+            Principal: '*'
+            Resource:
+              - !GetAtt TrustedIpsBucket.Arn
+              - !Sub '${TrustedIpsBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': false
 
 Outputs:
   BucketName:


### PR DESCRIPTION
Add bucket policy denying any traffic not over https to address CIS 2.1.2.

[1] https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
