### PR TITLE
[DCA-37] Export HostedZone NS records

### DIFF
--- a/templates/R53-hostedzone.yaml
+++ b/templates/R53-hostedzone.yaml
@@ -39,6 +39,8 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-HostedZoneId'
   HostedZoneNameServers:
-    Value: !GetAtt HostedZone.NameServers
+    Value: !Join
+      - ','
+      - !GetAtt HostedZone.NameServers
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-HostedZoneNameServers'

--- a/templates/R53-hostedzone.yaml
+++ b/templates/R53-hostedzone.yaml
@@ -38,3 +38,7 @@ Outputs:
     Value: !Ref HostedZone
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-HostedZoneId'
+  HostedZoneNameServers:
+    Value: !GetAtt HostedZone.NameServers
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-HostedZoneNameServers'


### PR DESCRIPTION
Export the name server records for the newly created hosted zone
to support automating delegation of subdomains.
