### PR TITLE
[IT-2703] Remove old tags from template parameters

### DIFF
--- a/templates/AddSameRegionBucketDownloadRestriction.yaml
+++ b/templates/AddSameRegionBucketDownloadRestriction.yaml
@@ -9,24 +9,6 @@ Parameters:
   BucketName:
     Type: String
     Description: Name of the bucket to which the same region AWS resource restriction bucket policy will be applied
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
 Resources:
   ExternalBucketGroupPolicyUpdateRole:
     Type: "AWS::IAM::Role"
@@ -136,13 +118,6 @@ Resources:
             except Exception as e:
                 cfnresponse.send(event, context, cfnresponse.FAILED, custom_resource_response_data)
                 raise
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ExternalBucketGroupPolicyUpdateSNSSubscription:
     Type: AWS::SNS::Subscription
     Properties:

--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -10,24 +10,6 @@ Parameters:
       - Enabled
       - Suspended
     Default: Suspended
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
 Resources:
   # Cloudformation bucket for CF templates
   AWSS3CloudformationBucket:
@@ -37,13 +19,6 @@ Resources:
       AccessControl: PublicRead
       VersioningConfiguration:
         Status: !Ref CfBucketVersioning
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   AWSIAMS3CloudformationBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -8,24 +8,6 @@ Parameters:
       - Enabled
       - Suspended
     Default: Suspended
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
 Resources:
   # Bucket for lambda artifacts
   AWSS3LambdaArtifactsBucket:
@@ -35,13 +17,6 @@ Resources:
       AccessControl: PublicRead
       VersioningConfiguration:
         Status: !Ref LambdaBucketVersioning
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   AWSIAMS3LambdaArtifactsBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:
@@ -104,13 +79,6 @@ Resources:
               - "kms:GenerateDataKey*"
               - "kms:DescribeKey"
             Resource: "*"
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   AWSKmsInfraKeyAlias:
     Type: AWS::KMS::Alias
     Properties:

--- a/templates/managed-alb-https-v2.yaml
+++ b/templates/managed-alb-https-v2.yaml
@@ -10,24 +10,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision an application load balancer listening on https
 Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   VpcId:
     Type: "AWS::EC2::VPC::Id"
     Description: The VPC Id for the ELB
@@ -76,13 +58,6 @@ Resources:
           FromPort: !Ref AppPort
           ToPort: !Ref AppPort
           SourceSecurityGroupId: !GetAtt ElbSecurityGroup.GroupId
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 
 # We need to attach Ec2SecurityGroup to the Ec2InstanceId.  CFN does
 # not allow attaching to SG to the default ENI.  A workaround is to
@@ -102,12 +77,6 @@ Resources:
 #            - '-'
 #            - - !Ref Ec2InstanceId
 #              - "ELB"
-#        - Key: "Department"
-#          Value: !Ref Department
-#        - Key: "Project"
-#          Value: !Ref Project
-#        - Key: "OwnerEmail"
-#          Value: !Ref OwnerEmail
 #  Ec2NetworkInterfaceAttach:
 #    Type: 'AWS::EC2::NetworkInterfaceAttachment'
 #    Properties:
@@ -133,13 +102,6 @@ Resources:
           FromPort: 80
           ToPort: 80
           CidrIp: 0.0.0.0/0
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElbTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -156,12 +118,6 @@ Resources:
             - '-'
             - - !Ref Ec2InstanceId
               - "ELB"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   LoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:
@@ -177,12 +133,6 @@ Resources:
             - '-'
             - - !Ref Ec2InstanceId
               - "ELB"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElbHttpsListener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:

--- a/templates/managed-alb-https.yaml
+++ b/templates/managed-alb-https.yaml
@@ -10,24 +10,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision an application load balancer listening on https
 Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   VpcId:
     Type: "AWS::EC2::VPC::Id"
     Description: The VPC Id for the ELB
@@ -76,13 +58,6 @@ Resources:
           FromPort: !Ref AppPort
           ToPort: !Ref AppPort
           SourceSecurityGroupId: !GetAtt ElbSecurityGroup.GroupId
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 
 # We need to attach Ec2SecurityGroup to the Ec2InstanceId.  CFN does
 # not allow attaching to SG to the default ENI.  A workaround is to
@@ -102,12 +77,6 @@ Resources:
 #            - '-'
 #            - - !Ref Ec2InstanceId
 #              - "ELB"
-#        - Key: "Department"
-#          Value: !Ref Department
-#        - Key: "Project"
-#          Value: !Ref Project
-#        - Key: "OwnerEmail"
-#          Value: !Ref OwnerEmail
 #  Ec2NetworkInterfaceAttach:
 #    Type: 'AWS::EC2::NetworkInterfaceAttachment'
 #    Properties:
@@ -133,13 +102,6 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElbTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -156,12 +118,6 @@ Resources:
             - '-'
             - - !Ref Ec2InstanceId
               - "ELB"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   LoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:
@@ -177,12 +133,6 @@ Resources:
             - '-'
             - - !Ref Ec2InstanceId
               - "ELB"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElbHttpListener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:

--- a/templates/managed-batch.yaml
+++ b/templates/managed-batch.yaml
@@ -6,24 +6,6 @@ Parameters:
   VpcName:
     Description: Name of an existing VPC to run the instance in.
     Type: String
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   ContainerImage:
     Description: The container image (i.e. 137112412989.dkr.ecr.us-east-1.amazonaws.com/amazonlinux:latest)
     Type: String
@@ -169,9 +151,6 @@ Resources:
         InstanceRole: !Ref 'IamInstanceProfile'
         Tags:
           Name: !Ref 'AWS::StackName'
-          Department: !Ref Department
-          Project: !Ref Project
-          OwnerEmail: !Ref OwnerEmail
       ServiceRole: !GetAtt BatchServiceRole.Arn
   SpotComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
@@ -196,9 +175,6 @@ Resources:
         SpotIamFleetRole: !GetAtt SpotIamFleetRole.Arn
         Tags:
           Name: !Ref 'AWS::StackName'
-          Department: !Ref Department
-          Project: !Ref Project
-          OwnerEmail: !Ref OwnerEmail
       ServiceRole: !GetAtt BatchServiceRole.Arn
   PeriodicSchedulerLambda:
     Condition: EnablePeriodicSchedule
@@ -207,21 +183,12 @@ Resources:
       # template uploaded from Sage-Bionetworks/aws-infra repo
       TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/aws-infra/master/periodic-batch-scheduler.yaml'
       Parameters:
-        Department: !Ref Department
-        Project: !Ref Project
-        OwnerEmail: !Ref OwnerEmail
         JobDefinitionArn: !Ref 'HighPriorityJobDefinition'
         JobQueueArn: !Ref 'HighPriorityJobQueue'
         ScheduleExpression: !Ref ScheduleExpression
       Tags:
         - Key: "Name"
           Value: !Ref 'AWS::StackName'
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 Outputs:
   HighPriorityJobDefinitionArn:
     Value: !Ref 'HighPriorityJobDefinition'

--- a/templates/managed-ebs.yaml
+++ b/templates/managed-ebs.yaml
@@ -2,24 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision a custom EBS volume and attach it to an instance
 Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   AvailabilityZone:
     Description: Availability Zone for the volume
     Type: "AWS::EC2::AvailabilityZone::Name"
@@ -92,12 +74,6 @@ Resources:
             - '-'
             - - !Ref Ec2InstanceId
               - !Ref AttachmentDevice
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   EbsAttachment:
     Type: AWS::EC2::VolumeAttachment
     Properties:

--- a/templates/managed-s3Web.yaml
+++ b/templates/managed-s3Web.yaml
@@ -13,21 +13,6 @@ Parameters:
     Type: String
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
     ConstraintDescription: must be a valid DNS zone name.
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
 Resources:
   WebsiteLogBucket:
     Type: 'AWS::S3::Bucket'
@@ -36,13 +21,6 @@ Resources:
       BucketName: !Join
         - '.'
         - [!Ref SubDomainName, !Ref DomainName, 'logs']
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   WebsiteBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -59,13 +37,6 @@ Resources:
         ErrorDocument: error.html
       LoggingConfiguration:
         DestinationBucketName: !Ref WebsiteLogBucket
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/templates/managed-s3WebCloudfront.yaml
+++ b/templates/managed-s3WebCloudfront.yaml
@@ -18,21 +18,6 @@ Parameters:
     Description: The Amazon Resource Name (ARN) of an AWS Certificate Manager (ACM) certificate.
     AllowedPattern: "arn:aws:acm:.*"
     ConstraintDescription: must be a valid certificate ARN.
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
 Resources:
   WebsiteLogBucket:
     Type: 'AWS::S3::Bucket'
@@ -41,13 +26,6 @@ Resources:
       BucketName: !Join
         - '.'
         - [!Ref SubDomainName, !Ref DomainName, 'logs']
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   WebsiteBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -64,13 +42,6 @@ Resources:
         ErrorDocument: error.html
       LoggingConfiguration:
         DestinationBucketName: !Ref WebsiteLogBucket
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -124,13 +95,6 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref AcmCertificateArn
           SslSupportMethod: sni-only
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 Outputs:
   CloudfrontId:
     Value: !Ref Cloudfront

--- a/templates/periodic-batch-scheduler.yaml
+++ b/templates/periodic-batch-scheduler.yaml
@@ -2,21 +2,6 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
   Lambda to schedule periodic execution of a batch job
 Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
   JobDefinitionArn:
     Description: Job definition ARN (i.e. arn:aws:batch:us-east-1:111111111111:job-definition/my-job:1)
     Type: String
@@ -129,12 +114,6 @@ Resources:
       Tags:
         - Key: "Name"
           Value: !Ref 'AWS::StackName'
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   LambdaPeriodicEvent:
     Type: AWS::Events::Rule
     Properties:

--- a/templates/transit-gateway-attachment.yaml
+++ b/templates/transit-gateway-attachment.yaml
@@ -2,24 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Setup an AWS transit gateway attachment
 Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   TransitGatewayId:
     Description: 'The transit gateway Id'
     Type: String
@@ -42,12 +24,6 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref 'AWS::StackName'
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
       TransitGatewayId: !Ref TransitGatewayId
       VpcId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -24,24 +24,6 @@ Parameters:
     Default: "10.50.0.0/16"
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Platform'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'Infrastructure'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'it@sagebase.org'
   IncludeS3GatewayEndpoint:
     Type: String
     Description: >
@@ -97,12 +79,6 @@ Resources:
           Value: "Public, Public1, Public2, Private, Private1, Private2"
         - Key: "Name"
           Value: !Ref VpcName
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -123,12 +99,6 @@ Resources:
           Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -148,12 +118,6 @@ Resources:
           Value: "Private"
         - Key: "Name"
           Value: "Private"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -174,12 +138,6 @@ Resources:
           Value: "Public1"
         - Key: "Name"
           Value: "Public1"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicSubnet2:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -200,12 +158,6 @@ Resources:
           Value: "Public2"
         - Key: "Name"
           Value: "Public2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -225,12 +177,6 @@ Resources:
           Value: "Private1"
         - Key: "Name"
           Value: "Private1"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateSubnet2:
     Type: "AWS::EC2::Subnet"
     Properties:
@@ -250,12 +196,6 @@ Resources:
           Value: "Private2"
         - Key: "Name"
           Value: "Private2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   InternetGateway:
     Type: "AWS::EC2::InternetGateway"
     Properties:
@@ -267,12 +207,6 @@ Resources:
           Value: "Public, Public1, Public2"
         - Key: "Name"
           Value: "Public, Public1, Public2"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   GatewayToInternet:
     Type: "AWS::EC2::VPCGatewayAttachment"
     Properties:
@@ -293,12 +227,6 @@ Resources:
           Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PublicRoute:
     Type: "AWS::EC2::Route"
     DependsOn: "GatewayToInternet"
@@ -342,12 +270,6 @@ Resources:
           Value: "Public"
         - Key: "Name"
           Value: "Public"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   InboundHTTPPublicNetworkAclEntry:
     Type: "AWS::EC2::NetworkAclEntry"
     Properties:
@@ -408,12 +330,6 @@ Resources:
         - Key: "Application"
           Value:
             Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   ElasticIP:
     Type: "AWS::EC2::EIP"
     Properties:
@@ -431,12 +347,6 @@ Resources:
           Value: "Private"
         - Key: "Name"
           Value: "Private"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   PrivateRouteToInternet:
     Type: "AWS::EC2::Route"
     Properties:
@@ -489,12 +399,6 @@ Resources:
         - Key: "Application"
           Value:
             Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   # Allow access to bastian hosts
   BastianSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -518,12 +422,6 @@ Resources:
         - Key: "Application"
           Value:
             Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   QuarantineSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -548,12 +446,6 @@ Resources:
         - Key: "Application"
           Value:
             Ref: "AWS::StackName"
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
   # Create VPC endpoint for all S3 traffic to avoid inter-AZ and NAT gateway traffic
   S3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint


### PR DESCRIPTION
Remove the Department and Project tags because we don't use them, and remove OwnerEmail because it should be applied to the entire stack and propagated to all resources within it.

We should increase the minor version to 0.7.x with this change.
