### PR TITLE
[IT-2768] Update role name for CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::745159704268:role/sagebase-github-oidc-sage-bio-ProviderRoleawsinfra-17DRC23HA177D
+        role-to-assume: arn:aws:iam::745159704268:role/sagebase-github-oidc-sage-bionetworks-awsinfra
         role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
         role-duration-seconds: 900
     - name: Copy files with the AWS CLI


### PR DESCRIPTION
The CI role names to assume will change due to PR
Sage-Bionetworks-IT/organizations-infra#859. update to the new role names

depends on Sage-Bionetworks-IT/organizations-infra#859
