### PR TITLE
[IT-2768] Remove importvalue from essentials template

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -8,6 +8,9 @@ Parameters:
       - Enabled
       - Suspended
     Default: Suspended
+  KmsInfraKeyPrincipals:
+    Type: String
+    Description: Principals that are allowed access to the infra kms key
 Resources:
   # Bucket for lambda artifacts
   AWSS3LambdaArtifactsBucket:
@@ -47,9 +50,7 @@ Resources:
             Sid: "Allow administration of the key"
             Effect: "Allow"
             Principal:
-              AWS:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-                - !ImportValue us-east-1-sagebase-github-oidc-sage-bionetworks-it-ProviderRoleArn-organizationsinfra
+              AWS: !Ref KmsInfraKeyPrincipals
             Action:
               - "kms:Create*"
               - "kms:Describe*"
@@ -68,10 +69,7 @@ Resources:
             Sid: "Allow use of the key"
             Effect: "Allow"
             Principal:
-              AWS:
-                - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-                - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRoleArn
-                - !ImportValue us-east-1-sagebase-github-oidc-sage-bionetworks-it-ProviderRoleArn-organizationsinfra
+              AWS: !Ref KmsInfraKeyPrincipals
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"


### PR DESCRIPTION
Using an `!ImportValue` makes one template depend on another. In this case the essentials stack depends on the OIDC stack. When we attempted to update the OIDC stack in PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/859 we got the following error..

```
Export us-east-1-sagebase-github-oidc-sage-bionetworks-it-ProviderRoleArn-organizationsinfra
cannot be deleted as it is in use by essentials
```

This required a temporary fix with PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/863

The right fix for this problem is to make the dependency a little looser.  We setup a parameter to pass in the values for the dependency.

