### PR TITLE
Revert "[IT-2768] Remove importvalue from essentials template (#387)"

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -8,9 +8,6 @@ Parameters:
       - Enabled
       - Suspended
     Default: Suspended
-  KmsInfraKeyPrincipals:
-    Type: String
-    Description: Principals that are allowed access to the infra kms key
 Resources:
   # Bucket for lambda artifacts
   AWSS3LambdaArtifactsBucket:
@@ -50,7 +47,9 @@ Resources:
             Sid: "Allow administration of the key"
             Effect: "Allow"
             Principal:
-              AWS: !Ref KmsInfraKeyPrincipals
+              AWS:
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+                - !ImportValue us-east-1-sagebase-github-oidc-sage-bionetworks-it-ProviderRoleArn-organizationsinfra
             Action:
               - "kms:Create*"
               - "kms:Describe*"
@@ -69,7 +68,10 @@ Resources:
             Sid: "Allow use of the key"
             Effect: "Allow"
             Principal:
-              AWS: !Ref KmsInfraKeyPrincipals
+              AWS:
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+                - !ImportValue us-east-1-bootstrap-SsmParamLambdaExecutionRoleArn
+                - !ImportValue us-east-1-sagebase-github-oidc-sage-bionetworks-it-ProviderRoleArn-organizationsinfra
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"


### PR DESCRIPTION
This reverts commit bf737b3ca0757de4c5e3c873ed7f602a37c0df18.
This attempt at fixing IT-2768 did not work.  cloudformation parameters
cannot take a list of strings

