### PR TITLE
fix KmsInfraKeyPrincipals parameter

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -9,7 +9,7 @@ Parameters:
       - Suspended
     Default: Suspended
   KmsInfraKeyPrincipals:
-    Type: String
+    Type: List<String>
     Description: Principals that are allowed access to the infra kms key
 Resources:
   # Bucket for lambda artifacts


### PR DESCRIPTION
small fix error from PR #387 
KmsInfraKeyPrincipals in essentials.yaml needs to be a list of strings