### PR TITLE
Allow updating tags on kms key in essentials stack

### DIFF
--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -52,18 +52,7 @@ Resources:
             Principal:
               AWS: !Ref KmsInfraKeyPrincipals
             Action:
-              - "kms:Create*"
-              - "kms:Describe*"
-              - "kms:Enable*"
-              - "kms:List*"
-              - "kms:Put*"
-              - "kms:Update*"
-              - "kms:Revoke*"
-              - "kms:Disable*"
-              - "kms:Get*"
-              - "kms:Delete*"
-              - "kms:ScheduleKeyDeletion"
-              - "kms:CancelKeyDeletion"
+              - "kms:*"
             Resource: "*"
           -
             Sid: "Allow use of the key"


### PR DESCRIPTION
This is another attempt to fix "Access denied for operation 'UntagResource'." The previous attempt in PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/867 was not enough to allow removing/adding
tags to KMS keys.  We need to explicitly allow that action in the key policy as well.
