### PR TITLE
PLFM-7886: Adding a template for an IAM Role

### DIFF
--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -8,15 +8,15 @@ Parameters:
     Description: Policy describing trust relationships
     Default: ''
   Policies:
-    Type: String
-    Description: In-line policy
-    Default: ''
+    Type: CommaDelimitedList
+    Description: In-line policies
+    Default: []
   ManagedPolicyArns:
-    Type: String
-    Description: ARNs of managed policies
-    Default: ''
+    Type: CommaDelimitedList
+    Default: []
+    Description: A list of managed policies for the role.
   MaxSessionDuration:
-    Type: Integer
+    Type: Number
     Description: Maximum session duration in seconds
     Default: 43200
   RoleName:

--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -1,0 +1,46 @@
+# Define a role
+#
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Creates a role'
+Parameters:
+  AssumeRolePolicyDocument:
+    Type: String
+    Description: Policy describing trust relationships
+    Default: ''
+  Policies:
+    Type: String
+    Description: In-line policy
+    Default: ''
+  ManagedPolicyArns:
+    Type: String
+    Description: ARNs of managed policies
+    Default: ''
+  MaxSessionDuration:
+    Type: Integer
+    Description: Maximum session duration in seconds
+    Default: 43200
+  RoleName:
+    Type: String
+    Description: Role name
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: !Ref AssumeRolePolicyDocument
+      Policies: !Ref Policies
+      ManagedPolicyArns: !Ref ManagedPolicyArns
+      MaxSessionDuration: !Ref MaxSessionDuration
+      RoleName: !Ref RoleName
+Outputs:
+  RoleName:
+    Value: !Ref Role
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RoleName'
+  RoleId:
+    Value: !GetAtt Role.RoleId
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RoleId'
+  RoleArn:
+    Value: !GetAtt Role.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RoleArn'

--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: Policy describing trust relationships
     Default: ''
   Policies:
-    Type: List<AWS:IAM:Policy>
+    Type: List<AWS::IAM::Policy>
     Description: In-line policies
     Default: ''
   ManagedPolicyArns:

--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -10,10 +10,10 @@ Parameters:
   Policies:
     Type: CommaDelimitedList
     Description: In-line policies
-    Default: []
+    Default: ''
   ManagedPolicyArns:
     Type: CommaDelimitedList
-    Default: []
+    Default: ''
     Description: A list of managed policies for the role.
   MaxSessionDuration:
     Type: Number

--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -7,10 +7,6 @@ Parameters:
     Type: String
     Description: Policy describing trust relationships
     Default: ''
-  Policies:
-    Type: List<AWS::IAM::Policy>
-    Description: In-line policies
-    Default: ''
   ManagedPolicyArns:
     Type: CommaDelimitedList
     Default: ''
@@ -27,7 +23,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument: !Ref AssumeRolePolicyDocument
-      Policies: !Ref Policies
       ManagedPolicyArns: !Ref ManagedPolicyArns
       MaxSessionDuration: !Ref MaxSessionDuration
       RoleName: !Ref RoleName

--- a/templates/IAM/iam-role.yaml
+++ b/templates/IAM/iam-role.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: Policy describing trust relationships
     Default: ''
   Policies:
-    Type: CommaDelimitedList
+    Type: List<AWS:IAM:Policy>
     Description: In-line policies
     Default: ''
   ManagedPolicyArns:


### PR DESCRIPTION
PLFM-7886 calls for enabling AWS Quicksight.
Quicksight requires a *role* it can assume, which has access to needed data sources.
`aws-infra` has no generic template for defining a role, so this PR adds such a template.