### PR TITLE
add MaxSessionDuration to GH OIDC role parameter

### DIFF
--- a/templates/IAM/github-oidc-provider.j2
+++ b/templates/IAM/github-oidc-provider.j2
@@ -57,6 +57,13 @@ Parameters:
             }
           ]
         }
+  MaxSessionDuration:
+    Type: Number
+    Description: "The IAM role's maximum session duration"
+    MaxValue: 43200
+    MinValue: 3600
+    Default: 3600
+
 Conditions:
   HasManagedPolicyArns: !Not
     - !Equals
@@ -79,6 +86,7 @@ Resources:
   ProviderRole{{ Repository.name | replace('-','') | replace('_','') }}:
     Type: AWS::IAM::Role
     Properties:
+      MaxSessionDuration: !Ref MaxSessionDuration
       # Concatinate managed policy and custom policy
       ManagedPolicyArns: !Split
         - ","


### PR DESCRIPTION
Allow user to specify max session duration when assuming a role

