### PR TITLE
Fix bootstrap template

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -16,7 +16,6 @@ Resources:
     Type: "AWS::S3::Bucket"
     DeletionPolicy: Delete
     Properties:
-      AccessControl: PublicRead
       VersioningConfiguration:
         Status: !Ref CfBucketVersioning
   AWSIAMS3CloudformationBucketPolicy:


### PR DESCRIPTION
AWS does not allow mixing ACLs and bucket policy configurations. AWS recommends not using ACLs going forward[1] so we remove references to ACLs.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html
