### PR TITLE
IT-3333: Add template to create a bucket for temporary data

### DIFF
--- a/templates/S3/temp-data-bucket.yaml
+++ b/templates/S3/temp-data-bucket.yaml
@@ -30,7 +30,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: true        
+        RestrictPublicBuckets: true
 
 Outputs:
   Bucket:

--- a/templates/S3/temp-data-bucket.yaml
+++ b/templates/S3/temp-data-bucket.yaml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  S3 Bucket to store temporary files,
+  accessed through API in SSO role
+Parameters:
+  LifecycleDataExpiration:
+    Type: Number
+    Description: Number of days (from creation) when objects are deleted from S3 and the LifecycleDataStorageClass
+    Default: 14
+  BucketName:
+    Type: String
+    Description: (Optional) Name of the created bucket.
+    Default: ""
+Conditions:
+  HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
+Resources:
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: Enabled
+          ExpirationInDays: !Ref LifecycleDataExpiration
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true        
+
+Outputs:
+  Bucket:
+    Value: !Ref Bucket
+    Export:
+      Name: !Sub '${AWS::StackName}-Bucket'
+  BucketArn:
+    Value: !GetAtt Bucket.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-BucketArn'


### PR DESCRIPTION
In SWC-6527, we need a bucket to temporarily store results of playwright tests (the files will be uploaded by GH workflow with OIDC) and retrieved for analysis as needed using the CLI/console). This PR creates a bucket with lifecycle expiration that expires the files after a number of days.
Primary user is the SWC project but other projects are looking at similar pattern so aws-infra seemed a more logical spot for the template.
