### PR TITLE
[IT-3313] Explicitly create public buckets

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -16,6 +16,13 @@ Resources:
     Type: "AWS::S3::Bucket"
     DeletionPolicy: Delete
     Properties:
+      PublicAccessBlockConfiguration:
+        # Explicitly comfigure public bucket
+        # https://repost.aws/questions/QUMcgxysOFRBmKIt9KRkYccg/api-s3-putbucketpolicy-access-denied-error-during-a-cloudformation-stack-creation
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       VersioningConfiguration:
         Status: !Ref CfBucketVersioning
   AWSIAMS3CloudformationBucketPolicy:

--- a/templates/essentials.yaml
+++ b/templates/essentials.yaml
@@ -17,7 +17,13 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      AccessControl: PublicRead
+      PublicAccessBlockConfiguration:
+        # Explicitly comfigure public bucket
+        # https://repost.aws/questions/QUMcgxysOFRBmKIt9KRkYccg/api-s3-putbucketpolicy-access-denied-error-during-a-cloudformation-stack-creation
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       VersioningConfiguration:
         Status: !Ref LambdaBucketVersioning
   AWSIAMS3LambdaArtifactsBucketPolicy:


### PR DESCRIPTION
Our bootstrap templates create public buckets to store cloudformation and lambda artifacts which is what we prefer. AWS changed the default account behavior to not allow creating public buckets[1].  To create public bucket we now must explicitly state that we want them to be public. This change does that.

[1] https://repost.aws/questions/QUMcgxysOFRBmKIt9KRkYccg/api-s3-putbucketpolicy-access-denied-error-during-a-cloudformation-stack-creation
