### PR TITLE
IT-3362: Fix policy

### DIFF
--- a/templates/IAM/snowflake-bucket-access.yaml
+++ b/templates/IAM/snowflake-bucket-access.yaml
@@ -33,7 +33,7 @@ Resources:
                 "s3:ListBucket",
                 "s3:GetBucketLocation"
               ],
-              "Resource": "${BucketArn}/${BucketPrefix}",
+              "Resource": "${BucketArn}",
               "Condition": {
                 "StringLike": {
                   "s3:prefix": "${BucketPrefix}/*"


### PR DESCRIPTION
This PR fixes the bucket permissions. The resource is the arn of the bucket and should not include the prefix.
