### PR TITLE
[IT-3425] Add policy to lambda role

### DIFF
--- a/templates/bootstrap.yaml
+++ b/templates/bootstrap.yaml
@@ -55,6 +55,7 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - !Ref DecryptSecureKeysPolicy
   DecryptSecureKeysPolicy:
     Type: 'AWS::IAM::ManagedPolicy'


### PR DESCRIPTION
The cfn-macro-ssm-param that uses the lambda execution role was not creating logs in cloudwatch because it lacked the permission to allow it.  We need to give it the AWSLambdaBasicExecutionRole to allow AWS to create cloudwatch logs for the lambda.

