### PR TITLE
[IT-3326] Update python version for PyPlate

### DIFF
--- a/templates/PyPlate/python.yaml
+++ b/templates/PyPlate/python.yaml
@@ -69,7 +69,7 @@ Resources:
               return macro_response
 
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.10
       Role: !GetAtt TransformExecutionRole.Arn
   TransformFunctionPermissions:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
AWS no longer supports python 3.6 so we need to Update the python version for the pyplate lambda

