### PR TITLE
[IT-3466] Upgrade cfn-cr-same-region-bucket-download version

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -181,7 +181,7 @@ Resources:
     Condition: CreateIPAddressRestrictionLambda
     Properties:
       # lambda from https://github.com/Sage-Bionetworks-IT/cfn-cr-same-region-bucket-download
-      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/cfn-cr-same-region-bucket-download/1.0.0/cfn-cr-same-region-bucket-download.yaml'
+      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/cfn-cr-same-region-bucket-download/1.0.1/cfn-cr-same-region-bucket-download.yaml'
       Parameters:
         BucketName: !Ref Bucket
 


### PR DESCRIPTION
Resolve an error deploying `S3/synapse-external-bucket.j2` by upgrading the python version in a nested lambda template.
