### PR TITLE
[IT-3471] templates to setup cloudwatch dashboard

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -4,5 +4,6 @@ ignore_checks:
   - E3001
   - W2001
   - W3045
+  - W8001
 ignore_templates:
   - templates/tags/*.json

--- a/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml
+++ b/templates/Cloudwatch/CrossAccountSharingRole-AccountList.yaml
@@ -1,0 +1,75 @@
+# This template is downloaded from the AWS Console (from org-sagebase-monitorcentral account)
+# Cloudwatch -> Settings -> Share your CloudWatch data -> Create CloudFormation stack
+# It should be deployed to all member accounts except for the org-sagebase-monitorcentral account
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Enables CloudWatch in central monitoring accounts to assume permissions to view CloudWatch data in the current account
+
+Parameters:
+  MonitoringAccountIds:
+    Description: Allows one or more monitoring accounts to view your data. Enter AWS account ids, 12 numeric digits in comma-separated list
+    Type: CommaDelimitedList
+
+  Policy:
+    Description: The level of access to give to the Monitoring accounts
+    Type: String
+    Default: CloudWatch-and-AutomaticDashboards
+    AllowedValues:
+      - CloudWatch-and-AutomaticDashboards
+      - CloudWatch-and-ServiceLens
+      - CloudWatch-AutomaticDashboards-and-ServiceLens
+      - CloudWatch-core-permissions
+      - View-Access-for-all-services
+
+Conditions:
+  DoFullReadOnly: !Equals [ !Ref Policy, View-Access-for-all-services ]
+  DoAutomaticDashboards: !Equals [ !Ref Policy, CloudWatch-and-AutomaticDashboards ]
+  DoServiceLens: !Equals [ !Ref Policy, CloudWatch-and-ServiceLens ]
+  DoServiceLensAndAutomaticDashboards: !Equals [ !Ref Policy, CloudWatch-AutomaticDashboards-and-ServiceLens ]
+  DoCWReadOnly: !Equals [ !Ref Policy, CloudWatch-core-permissions ]
+
+Resources:
+  CWCrossAccountSharingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CloudWatch-CrossAccountSharingRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Split
+                - ','
+                - !Sub
+                  - 'arn:aws:iam::${inner}:root'
+                  - inner: !Join
+                      - ':root,arn:aws:iam::'
+                      - Ref: MonitoringAccountIds
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns: !If
+        - DoFullReadOnly
+        -
+          - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+          - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+          - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+          - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+        - !If
+          - DoAutomaticDashboards
+          -
+            - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+            - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+          - !If
+            - DoServiceLens
+            -
+              - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+              - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+            - !If
+              - DoServiceLensAndAutomaticDashboards
+              -
+                - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+                - arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess
+                - arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess
+              -
+                - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess

--- a/templates/Cloudwatch/Link-Management-Account.yaml
+++ b/templates/Cloudwatch/Link-Management-Account.yaml
@@ -1,0 +1,25 @@
+# This template is downloaded from the AWS Console (from org-sagebase-monitorcentral account)
+# Cloudwatch -> Settings -> Determine how to link your source accounts
+# It should be deployed to all member accounts except for the org-sagebase-monitorcentral account
+
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  MonitoringAccountId:
+    Description: Allows one or more monitoring accounts to view your data. Enter AWS account ids, 12 numeric digits in comma-separated list
+    Type: String
+  SinkIdentifier:
+    Description: ID of the attachment point in the cloudwatch monitoring account.
+    Type: String
+
+Resources:
+  Link:
+    Type: AWS::Oam::Link
+    Properties:
+      LabelTemplate: "$AccountName"
+      ResourceTypes:
+        - "AWS::CloudWatch::Metric"
+        - "AWS::Logs::LogGroup"
+        - "AWS::XRay::Trace"
+        - "AWS::ApplicationInsights::Application"
+      SinkIdentifier: !Sub "arn:aws:oam:us-east-1:${MonitoringAccountId}:sink/${SinkIdentifier}"


### PR DESCRIPTION
move files from org-formation[1] repo to here so it can be shared from multiple deployments.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/tree/master/org-formation/740-cloudwatch-dashboard

