### PR TITLE
specify HeadObject action in bucket policy

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -115,7 +115,7 @@ Resources:
             Principal:
               AWS: !Ref GrantAccess
             Action:
-              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
+              - !If [AllowWrite, "s3:*Object*", "s3:GetObject", "s3:HeadObject"]
               - "s3:*MultipartUpload*"
             Condition:
               StringEquals:


### PR DESCRIPTION
Users have been receiving ‘Access denied when performing HeadObject’ errors on a scicomp bucket that we provisioned for them. To address this issue, I've explicitly added HeadObject to the policy. 