### PR TITLE
add HeadObject to Read Object Access Permissions

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -139,6 +139,7 @@ Resources:
               - "s3:GetObject"
               - "s3:GetObjectAcl"
               - "s3:ListMultipartUploadParts"
+              - "s3:HeadObject"
             Resource: [ !Sub "${Bucket.Arn}/*" ]
           - !If
             - AllowWrite


### PR DESCRIPTION
Collaborators who are accessing a bucket created from the synapse-external-bucket.j2 template are encountering "Access denied when performing HeadObject" errors. This PR addresses this issue by explicitly granting HeadObject permissions to principals who have read access to the bucket. 