### PR TITLE
add GetObjectAttributes to synapse external bucket template

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -139,7 +139,7 @@ Resources:
               - "s3:GetObject"
               - "s3:GetObjectAcl"
               - "s3:ListMultipartUploadParts"
-              - "s3:HeadObject"
+              - "s3:GetObjectAttributes"
             Resource: [ !Sub "${Bucket.Arn}/*" ]
           - !If
             - AllowWrite


### PR DESCRIPTION
Due to a failed deployment using HeadObject in scicomp (https://github.com/Sage-Bionetworks/scicomp-provisioner/actions/runs/8527855786/job/23360215378), this PR replaces HeadObject with GetObjectAttributes