### PR TITLE
Add *ObjectTagging perms

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -137,6 +137,7 @@ Resources:
               AWS: !Ref GrantAccess
             Action:
               - "s3:GetObject"
+              - "s3:GetObjectTagging"
               - "s3:GetObjectAcl"
               - "s3:ListMultipartUploadParts"
               - "s3:GetObjectAttributes"
@@ -150,6 +151,7 @@ Resources:
                 AWS: !Ref GrantAccess
               Action:
                 - "s3:PutObject"
+                - "s3:PutObjectTagging"
                 - "s3:PutObjectAcl"
                 - "s3:DeleteObject*"
                 - "s3:*MultipartUpload*"


### PR DESCRIPTION
Following up on Slack thread re: moving objects in an external bucket and running into 'An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied', this PR adds the permissions to the grantees.
