### PR TITLE
[IT-3953] Update same region bucket lambda

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -184,7 +184,7 @@ Resources:
     Condition: CreateIPAddressRestrictionLambda
     Properties:
       # lambda from https://github.com/Sage-Bionetworks-IT/cfn-cr-same-region-bucket-download
-      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/cfn-cr-same-region-bucket-download/1.0.1/cfn-cr-same-region-bucket-download.yaml'
+      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/cfn-cr-same-region-bucket-download/1.0.2/cfn-cr-same-region-bucket-download.yaml'
       Parameters:
         BucketName: !Ref Bucket
 


### PR DESCRIPTION
The cfn-cr-same-region-bucket-download lambda was failing to deploy with the scicomp-provisioner[1] with the following error..

```
[2024-10-18 16:34:58] - prod/htan2-testing1 IPAddressRestictionLambda
AWS::CloudFormation::Stack CREATE_FAILED Embedded stack
arn:aws:cloudformation:us-east-1:***:stack/htan2-testing1-IPAddressRestictionLambda-1534XYHGZI8V8/cd414320-8d6e-11ef-a975-0affca4facf5
was not successfully created: The following resource(s) failed to create: [RestrictBucketDownloadRegionFunction].
```

We neglected to update the S3 template to use the latest version of the lambda  which was missing an update of dependencies[2].

[1] https://github.com/Sage-Bionetworks/scicomp-provisioner
[2] https://github.com/Sage-Bionetworks-IT/cfn-cr-same-region-bucket-download/commit/0316d97015eca362478586482a7d6ff50888c963

