### PR TITLE
[IT-4144] CIS 5.1 Restrict source IP for SSH/RDP

### DIFF
--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -280,6 +280,61 @@ Resources:
           Value: "Public"
         - Key: "Name"
           Value: "Public"
+  InboundAllowLocalNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 96
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: false
+      CidrBlock: !Join
+        - '.'
+        - - !Ref VpcSubnetPrefix
+          - !FindInMap [SubnetConfig, VPC, CIDR]
+      PortRange:
+        From: 0
+        To: 65535
+  InboundAllowVpnNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 97
+      Protocol: -1
+      RuleAction: "allow"
+      Egress: false
+      CidrBlock: !Ref VpnCidr
+      PortRange:
+        From: 0
+        To: 65535
+  InboundBlockPublicSshNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: "deny"
+      Egress: false
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 22
+        To: 22
+  InboundBlockPublicRdpNetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      NetworkAclId:
+        Ref: "PublicNetworkAcl"
+      RuleNumber: 99
+      Protocol: -1
+      RuleAction: "deny"
+      Egress: false
+      CidrBlock: "0.0.0.0/0"
+      PortRange:
+        From: 3389
+        To: 3389
   InboundHTTPPublicNetworkAclEntry:
     Type: "AWS::EC2::NetworkAclEntry"
     Properties:


### PR DESCRIPTION
The network ACL applies to the entire VPC, effecting both public and private subnets.

Modify the ACL to allow all traffic within the VPC and from the VPN, deny any other traffic to SSH or RDP, and allow all other traffic.
