### PR TITLE
[IT-2361] Fix nextflow batch compute env template

### DIFF
--- a/templates/NextflowTower/nextflow-launch.yaml
+++ b/templates/NextflowTower/nextflow-launch.yaml
@@ -7,12 +7,24 @@ Parameters:
   SubnetIds:
     Type: CommaDelimitedList
     Description: List of public Subnet Ids for the load balancer
+  MinvCpus:
+    Type: Number
+    Description: The number of min CPUs for Batch compute environments
+    MinValue: 0
+    MaxValue: 16
+    Default: 0
   MaxvCpus:
     Type: Number
     Description: The number of max CPUs for Batch compute environments
-    MinValue: 1
-    MaxValue: 16
-    Default: 1
+    MinValue: 8
+    MaxValue: 64
+    Default: 8
+  DesiredvCpus:
+    Type: Number
+    Description: The number of desired CPUs for Batch compute environments
+    MinValue: 0
+    MaxValue: 8
+    Default: 0
 Resources:
   UserManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -78,21 +90,6 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
-  InstanceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2008-10-17'
-        Statement:
-          - Sid: ''
-            Effect: Allow
-            Principal:
-              Service: ec2.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - !Ref JobManagedPolicy
   SpotFleetRole:
     Type: AWS::IAM::Role
     Properties:
@@ -106,6 +103,27 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
+  BatchInstanceIAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: 'Allow'
+            Principal:
+              Service:
+                - 'ec2.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role'
+  BatchInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: /
+      Roles:
+        - !Ref BatchInstanceIAMRole
   ComputeEnvironmentOnDemand:
     Type: AWS::Batch::ComputeEnvironment
     Metadata:
@@ -119,15 +137,17 @@ Resources:
       ServiceRole: !Ref BatchServiceRole
       ComputeResources:
         Type: EC2
+        MinvCpus: !Ref MinvCpus
         MaxvCpus: !Ref MaxvCpus
+        DesiredvCpus: !Ref DesiredvCpus
         Subnets: !Ref SubnetIds
         SecurityGroupIds:
           - !Ref EcsSecurityGroupId
-        InstanceRole: !Ref InstanceRole
+        InstanceRole: !Ref BatchInstanceProfile
+        InstanceTypes:
+          - optimal
         LaunchTemplate:
           LaunchTemplateId: !ImportValue
-            'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplate'
-          LaunchTemplateName: !ImportValue
             'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplate'
           Version: !ImportValue
             'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplateLatestVersionNumber'
@@ -144,16 +164,18 @@ Resources:
       ServiceRole: !Ref BatchServiceRole
       ComputeResources:
         Type: SPOT
+        MinvCpus: !Ref MinvCpus
         MaxvCpus: !Ref MaxvCpus
+        DesiredvCpus: !Ref DesiredvCpus
         Subnets: !Ref SubnetIds
         SecurityGroupIds:
           - !Ref EcsSecurityGroupId
         SpotIamFleetRole: !Ref SpotFleetRole
-        InstanceRole: !Ref InstanceRole
+        InstanceRole: !Ref BatchInstanceProfile
+        InstanceTypes:
+          - optimal
         LaunchTemplate:
           LaunchTemplateId: !ImportValue
-            'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplate'
-          LaunchTemplateName: !ImportValue
             'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplate'
           Version: !ImportValue
             'Fn::Sub': '${AWS::Region}-nextflow-ecs-cluster-EcsLaunchTemplateLatestVersionNumber'
@@ -178,10 +200,10 @@ Outputs:
     Value: !Ref BatchServiceRole
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-BatchServiceRole'
-  InstanceRole:
-    Value: !Ref InstanceRole
+  BatchInstanceIAMRole:
+    Value: !Ref BatchInstanceIAMRole
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-InstanceRole'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BatchInstanceIAMRole'
   SpotFleetRole:
     Value: !Ref SpotFleetRole
     Export:


### PR DESCRIPTION
* Fix launch template reference.  It can only take one of name or id.
* Fix batch role to resolve the following stabalization failure:
```
Resource handler returned message: "Resource of type
'AWS::Batch::ComputeEnvironment' with identifier
'arn:aws:batch:us-east-1:035458030717:compute-environment/ComputeEnvironmentSpot-eULJVaK00uH15ZfV'
did not stabilize."
```
