### PR TITLE
PLFM-8908 template to add CIS Level 1 image image builder for Synapse

### DIFF
--- a/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
+++ b/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
@@ -1,0 +1,138 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  AwsOrganizationId:
+    Description: Share the generated image with this Organization
+    Type: String
+    Default: "o-69lcdj4kro"
+  ImageVersion:
+    Description: The generated image version.
+    Type: String
+    Default: "0.0.0"
+  VolumeSize:
+    Description: The EBS volume size (in GB)
+    Type: Number
+    Default: 50
+    MinValue: 8
+    MaxValue: 500
+Resources:
+  # By default, AWS Services do not have permission to perform actions on your instances. This grants
+  # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build an image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+  # https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-setting-up.html
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      Comment: Role to be used by instance during image build.
+    Properties:
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub 'ec2.${AWS::URLSuffix}'
+        Version: '2012-10-17'
+      Path: /executionServiceEC2Role/
+  # To pass the InstanceRole to an EC2 instance, we need an InstanceProfile.
+  # This profile will be used during the image build process.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - Ref: InstanceRole
+
+  ImageBuilderImagePipeline:
+    Type: "AWS::ImageBuilder::ImagePipeline"
+    Properties:
+      Name: !Sub ${AWS::StackName}
+      Status: "ENABLED"
+      Schedule:
+        ScheduleExpression:
+          rate(7 days)
+      InfrastructureConfigurationArn:
+        Ref: ImageInfrastructureConfiguration
+      ImageScanningConfiguration:
+        ImageScanningEnabled: true
+      ImageRecipeArn:
+        Ref: Recipe
+      DistributionConfigurationArn:
+        Ref: ImageDistributionConfiguration
+      ImageTestsConfiguration:
+        TimeoutMinutes: 720
+        ImageTestsEnabled: true
+
+  Recipe:
+    Type: "AWS::ImageBuilder::ImageRecipe"
+    Properties:
+      Name: !Sub ${AWS::StackName}
+      Version: !Ref ImageVersion
+      ParentImage:
+        Fn::Sub: arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/cis-hardened-image-level-1-on-amazon-linux-2023-arm-r5sqt5uxgygqi/x.x.x
+      Components:
+        - ComponentArn:
+            Ref: CISforEBImageBuilderComponent
+      # The image will not build with the default working dir, /tmp, since CIS makes that directory non-executable
+      WorkingDirectory: "/root"
+      BlockDeviceMappings:
+      - Ebs:
+          Throughput: 125
+          VolumeType: gp3
+          Iops: 3000
+          VolumeSize: !Ref VolumeSize
+          DeleteOnTermination: true
+        DeviceName: "/dev/xvda"
+      AdditionalInstanceConfiguration:
+        SystemsManagerAgent:
+          UninstallAfterBuild: false
+
+  CISforEBImageBuilderComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: CISforEBImageBuilderComponent
+      Version: 1.0.0
+      Description: Modify CIS Level 1 image to work with Elastic Beanstalk
+      Platform: Linux
+      Data: |
+        name: cis-eb-fixes
+        description: Updates to CIS hardened images to make it work with Elastic Beanstalk
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: xray-group
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - sudo /usr/sbin/useradd --user-group xray -s /sbin/nologin --no-create-home
+
+  # Specifies the infrastructure within which to build and test your image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html
+  ImageInfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: !Sub '${AWS::StackName}-Configuration'
+      InstanceProfileName:
+        Ref: InstanceProfile
+
+  ImageDistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: !Sub '${AWS::StackName}-Distributions'
+      Distributions:
+        - Region: !Ref 'AWS::Region'
+          AmiDistributionConfiguration:
+            AmiTags:    # apply tags to generated AMIs
+              Name: !Sub '${AWS::StackName}'
+            LaunchPermissionConfiguration:
+              OrganizationArns:
+                - !Sub 'arn:${AWS::Partition}:organizations::${AWS::AccountId}:organization/${AwsOrganizationId}'
+              UserIds:
+                - 449435941126   # Synapse dev
+                - 325565585839   # Synapse prod


### PR DESCRIPTION
This PR adds a template to create an image builder pipeline to build a CIS Level 1 hardened image which will work with Elastic Beanstalk, for use by Synapse.