### PR TITLE
Resolve Security hub 2.1.5.2 finding

### DIFF
--- a/templates/S3/synapse-external-bucket.j2
+++ b/templates/S3/synapse-external-bucket.j2
@@ -91,7 +91,6 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
-
       LifecycleConfiguration:
         Rules:
         - Id: DataLifecycleRule
@@ -100,6 +99,11 @@ Resources:
           Transitions:
             - TransitionInDays: !Ref LifecycleDataTransition
               StorageClass: !Ref LifecycleDataStorageClass
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   BucketPolicy:
     Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
Security hub will report finding
`2.1.5.2 S3 Block Public Access setting should be enabled at the bucket-level` if `Block all public access` is not enabled on non-public buckets.  We enable that configuration for synapse buckets.
