### PR TITLE
SAGL-72: Fixed illegal step names

### DIFF
--- a/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
+++ b/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
@@ -111,13 +111,13 @@ Resources:
                 inputs:
                   commands:
                     - sudo /usr/sbin/useradd --user-group xray -s /sbin/nologin --no-create-home
-              - name: CIS-5.1.1.4
+              - name: CIS-5114
                 # Edit ... /etc/rsyslog.conf ... and set $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640
                 action: ExecuteBash
                 inputs:
                   commands:
                     - sudo sed -i "s|#### GLOBAL DIRECTIVES ####|#### GLOBAL DIRECTIVES ####\n\$FileCreateMode 0640|g" /etc/rsyslog.conf
-              - name: CIS-5.1.1.3
+              - name: CIS-5113
                 # Ensure journald is configured to send logs to rsyslog. Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes
                 action: ExecuteBash
                 inputs:

--- a/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
+++ b/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
@@ -116,7 +116,7 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
-                    - sudo sed -i "s|#### GLOBAL DIRECTIVES ####|#### GLOBAL DIRECTIVES ####\n\$FileCreateMode 0640|g" /etc/rsyslog.conf
+                    - sudo echo "\\$FileCreateMode 0640" >> /etc/rsyslog.conf
               - name: CIS-5113
                 # Ensure journald is configured to send logs to rsyslog. Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes
                 action: ExecuteBash


### PR DESCRIPTION
It looks like step names can't contain periods.  
I removed the periods and "manually" ran the CF template to make sure there were not any other issues.