### PR TITLE
SAGL-341 Create journald upload directory

### DIFF
--- a/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
+++ b/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml
@@ -163,11 +163,15 @@ Resources:
               - name: CIS-6_1_12
                 # "Ensure no unowned or ungrouped files or directories exist"
                 # There is an empty directory, /var/lib/private/systemd/journal-upload,
-                # whose owner is a non-existent user.  Delete the empty directory.
+                # whose owner is a non-existent user.
+                #
+                # The user is a temporary user created by systemd-journal-upload
+                # everything gets cleaned up except this lingering directory
+                # The workaround is simply to create the directory as root and let other users access it
                 action: ExecuteBash
                 inputs:
                   commands:
-                    - rmdir /var/lib/private/systemd/journal-upload
+                    - mkdir -p -m 777 /var/lib/private/systemd/journal-upload
               - name: CIS_4_6_2
                 # Ensure system accounts are secured
                 # finds that the user 'webapp' does not have the 'nologin' option


### PR DESCRIPTION
CIS flags the folder /`var/lib/private/systemd/journal-upload` as a security risk because it belongs to a non-existent user, id=63150.    We tried addressing the problem by deleting the folder, but it gets recreated.  It turns out this is because "systemd-journal-upload ... uses a temporary user that only exists while the process is running." [reference](https://www.digitalocean.com/community/tutorials/how-to-centralize-logs-with-journald-on-ubuntu-20-04)

In this PR we try the approach of creating the directory in advance with a different owner (root) and with permissions which will allow access to the temporary user later created by `systemd-journal-upload `.