### PR TITLE
update description for ExternalId

### DIFF
--- a/templates/IAM/cross-account-access.yaml
+++ b/templates/IAM/cross-account-access.yaml
@@ -29,12 +29,12 @@ Parameters:
           ]
         }
   # ExternalId supports dynamic references. Examples:
-  #   ExternalId: "{{resolve:secretsmanager:my-secret-name:SecretString:my-secret-key}}"
+  #   ExternalId: "{{resolve:secretsmanager:my-secrets:SecretString:my-secret-key}}"
   ExternalId:
     Type: String
     Default: ""
     Description: >-
-      An optional dynamic reference to the AWS Secrets Manager containing the secret value
+      An optional dynamic reference to the AWS Secrets Manager containing the ExternalId value
   PrincipalArns:
     Type: CommaDelimitedList
     Description: >-

--- a/templates/IAM/cross-account-access.yaml
+++ b/templates/IAM/cross-account-access.yaml
@@ -29,14 +29,12 @@ Parameters:
           ]
         }
   # ExternalId supports dynamic references. Examples:
-  #   ExternalId: "{{resolve:secretsmanager:my-secret:SecretString:ExternalId}}"
-  #   ExternalId: "{{resolve:ssm-secure:/path/to/external-id}}"
+  #   ExternalId: "{{resolve:secretsmanager:my-secret-name:SecretString:my-secret-key}}"
   ExternalId:
     Type: String
     Default: ""
     Description: >-
-      An optional external ID to prevent the confused deputy problem.
-      A dynamic reference to Secrets Manager or SSM Parameter Store.
+      An optional dynamic reference to the AWS Secrets Manager containing the secret value
   PrincipalArns:
     Type: CommaDelimitedList
     Description: >-


### PR DESCRIPTION
cloudformation resolvers does not support resolving with the
SSM, it only works with the AWS Secrets manager.





#### PR Dependency Tree


* **PR #443** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)